### PR TITLE
feat: drop the need to specify an extractor

### DIFF
--- a/src/commands/extract/check.ts
+++ b/src/commands/extract/check.ts
@@ -2,7 +2,7 @@ import type { BaseExtractOptions } from '../extract';
 import { relative } from 'path';
 import { Command } from 'commander';
 
-import { extractKeysOfFiles } from '../../extractor';
+import { extractKeysOfFiles } from '../../extractor/runner';
 import { WarningMessages, emitGitHubWarning } from '../../extractor/warnings';
 import { loading } from '../../utils/logger';
 

--- a/src/commands/extract/print.ts
+++ b/src/commands/extract/print.ts
@@ -2,7 +2,7 @@ import type { BaseExtractOptions } from '../extract';
 import { relative } from 'path';
 import { Command } from 'commander';
 
-import { extractKeysOfFiles } from '../../extractor';
+import { extractKeysOfFiles } from '../../extractor/runner';
 import { WarningMessages } from '../../extractor/warnings';
 import { loading } from '../../utils/logger';
 

--- a/src/commands/sync/compare.ts
+++ b/src/commands/sync/compare.ts
@@ -3,7 +3,10 @@ import { Command } from 'commander';
 import ansi from 'ansi-colors';
 
 import { compareKeys, printKey } from './syncUtils';
-import { extractKeysOfFiles, filterExtractionResult } from '../../extractor/runner';
+import {
+  extractKeysOfFiles,
+  filterExtractionResult,
+} from '../../extractor/runner';
 import { dumpWarnings } from '../../extractor/warnings';
 import { EXTRACTOR } from '../../options';
 import { loading } from '../../utils/logger';

--- a/src/commands/sync/compare.ts
+++ b/src/commands/sync/compare.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander';
 import ansi from 'ansi-colors';
 
 import { compareKeys, printKey } from './syncUtils';
-import { extractKeysOfFiles, filterExtractionResult } from '../../extractor';
+import { extractKeysOfFiles, filterExtractionResult } from '../../extractor/runner';
 import { dumpWarnings } from '../../extractor/warnings';
 import { EXTRACTOR } from '../../options';
 import { loading } from '../../utils/logger';

--- a/src/commands/sync/sync.ts
+++ b/src/commands/sync/sync.ts
@@ -3,7 +3,7 @@ import type Client from '../../client';
 import { Command } from 'commander';
 import ansi from 'ansi-colors';
 
-import { extractKeysOfFiles, filterExtractionResult } from '../../extractor';
+import { extractKeysOfFiles, filterExtractionResult } from '../../extractor/runner';
 import { dumpWarnings } from '../../extractor/warnings';
 import { type PartialKey, compareKeys, printKey } from './syncUtils';
 

--- a/src/commands/sync/sync.ts
+++ b/src/commands/sync/sync.ts
@@ -3,7 +3,10 @@ import type Client from '../../client';
 import { Command } from 'commander';
 import ansi from 'ansi-colors';
 
-import { extractKeysOfFiles, filterExtractionResult } from '../../extractor/runner';
+import {
+  extractKeysOfFiles,
+  filterExtractionResult,
+} from '../../extractor/runner';
 import { dumpWarnings } from '../../extractor/warnings';
 import { type PartialKey, compareKeys, printKey } from './syncUtils';
 

--- a/src/commands/sync/syncUtils.ts
+++ b/src/commands/sync/syncUtils.ts
@@ -1,5 +1,6 @@
 import type { AllKeys } from '../../client/project';
-import { type FilteredKeys, type Key, NullNamespace } from '../../extractor';
+import type { Key } from '../../extractor';
+import { type FilteredKeys, NullNamespace } from '../../extractor/runner';
 import ansi from 'ansi-colors';
 
 export type PartialKey = { keyName: string; namespace?: string };

--- a/src/config/tolgeerc.ts
+++ b/src/config/tolgeerc.ts
@@ -1,4 +1,6 @@
 import { cosmiconfig, defaultLoaders } from 'cosmiconfig';
+import { resolve } from 'path';
+import { existsSync } from 'fs';
 import { SDKS } from '../constants';
 
 export type ProjectSdk = typeof SDKS[number];
@@ -58,10 +60,12 @@ function parseConfig(rc: any): TolgeeConfig {
       throw new Error('Invalid config: extractor is not a string');
     }
 
-    cfg.extractor = rc.extractor;
-  } else {
-    // Re-use the SDK config as a fallback
-    cfg.extractor = cfg.sdk;
+    const extractorPath = resolve(rc.extractor)
+    if (!existsSync(extractorPath)) {
+      throw new Error(`Invalid config: extractor points to a file that does not exists (${extractorPath})`);
+    }
+
+    cfg.extractor = extractorPath;
   }
 
   if ('delimiter' in rc) {

--- a/src/config/tolgeerc.ts
+++ b/src/config/tolgeerc.ts
@@ -60,9 +60,11 @@ function parseConfig(rc: any): TolgeeConfig {
       throw new Error('Invalid config: extractor is not a string');
     }
 
-    const extractorPath = resolve(rc.extractor)
+    const extractorPath = resolve(rc.extractor);
     if (!existsSync(extractorPath)) {
-      throw new Error(`Invalid config: extractor points to a file that does not exists (${extractorPath})`);
+      throw new Error(
+        `Invalid config: extractor points to a file that does not exists (${extractorPath})`
+      );
     }
 
     cfg.extractor = extractorPath;

--- a/src/extractor/index.ts
+++ b/src/extractor/index.ts
@@ -1,14 +1,3 @@
-import { join, extname } from 'path';
-import { existsSync } from 'fs';
-import { glob as globCb } from 'glob';
-
-import { callWorker } from './worker';
-
-import { promisify } from 'util';
-const glob = promisify(globCb);
-
-export const NullNamespace = Symbol('namespace.null');
-
 export type Key = {
   keyName: string;
   defaultValue?: string;
@@ -23,72 +12,9 @@ export type Warning = { warning: string; line: number };
 
 export type Extractor = (fileContents: string, fileName: string) => string[];
 
-export type ExtractionResult = Map<
+export type ExtractionResult = { keys: ExtractedKey[]; warnings: Warning[] };
+
+export type ExtractionResults = Map<
   string,
   { keys: ExtractedKey[]; warnings: Warning[] }
 >;
-
-export type FilteredKeys = {
-  [NullNamespace]: Map<string, string | null>;
-  [key: string]: Map<string, string | null>;
-};
-
-function resolveExtractor(extractor: string): string {
-  if (!existsSync(extractor)) {
-    // During dev, we deal with .ts files because of ts-node
-    const preset = join(
-      __dirname,
-      'presets',
-      `${extractor}${extname(__filename)}`
-    );
-
-    if (!existsSync(preset)) {
-      throw new Error(`Cannot find specified extractor: ${extractor}`);
-    }
-
-    return preset;
-  }
-
-  return extractor;
-}
-
-export async function extractKeysFromFile(file: string, extractor: string) {
-  return callWorker({
-    extractor: resolveExtractor(extractor),
-    file: file,
-  });
-}
-
-export async function extractKeysOfFiles(
-  filesPattern: string,
-  extractor: string
-) {
-  const files = await glob(filesPattern, { nodir: true });
-  const result = new Map<
-    string,
-    { keys: ExtractedKey[]; warnings: Warning[] }
-  >();
-
-  for (const file of files) {
-    const keys = await extractKeysFromFile(file, extractor);
-    result.set(file, keys);
-  }
-
-  return result;
-}
-
-export function filterExtractionResult(data: ExtractionResult): FilteredKeys {
-  const result: FilteredKeys = Object.create(null);
-  for (const { keys } of data.values()) {
-    for (const key of keys) {
-      const namespace = key.namespace || NullNamespace;
-      if (!(namespace in result)) {
-        result[namespace] = new Map();
-      }
-
-      result[namespace].set(key.keyName, key.defaultValue || null);
-    }
-  }
-
-  return result;
-}

--- a/src/extractor/runner.ts
+++ b/src/extractor/runner.ts
@@ -1,0 +1,54 @@
+import type { ExtractionResults } from '.';
+import { glob as globCb } from 'glob';
+
+import { callWorker } from './worker';
+
+import { promisify } from 'util';
+const glob = promisify(globCb);
+
+export const NullNamespace = Symbol('namespace.null');
+
+export type FilteredKeys = {
+  [NullNamespace]: Map<string, string | null>;
+  [key: string]: Map<string, string | null>;
+};
+
+export async function extractKeysFromFile(file: string, extractor?: string) {
+  return callWorker({
+    extractor: extractor,
+    file: file,
+  });
+}
+
+export async function extractKeysOfFiles(
+  filesPattern: string,
+  extractor: string
+) {
+  const files = await glob(filesPattern, { nodir: true });
+  const result: ExtractionResults = new Map();
+
+  await Promise.all(
+    files.map(async (file) => {
+      const keys = await extractKeysFromFile(file, extractor);
+      result.set(file, keys);
+    })
+  );
+
+  return result;
+}
+
+export function filterExtractionResult(data: ExtractionResults): FilteredKeys {
+  const result: FilteredKeys = Object.create(null);
+  for (const { keys } of data.values()) {
+    for (const key of keys) {
+      const namespace = key.namespace || NullNamespace;
+      if (!(namespace in result)) {
+        result[namespace] = new Map();
+      }
+
+      result[namespace].set(key.keyName, key.defaultValue || null);
+    }
+  }
+
+  return result;
+}

--- a/src/extractor/warnings.ts
+++ b/src/extractor/warnings.ts
@@ -1,4 +1,4 @@
-import type { ExtractionResult } from '.';
+import type { ExtractionResults } from '.';
 import { relative } from 'path';
 
 export type WarningMessage = { name: string; description: string };
@@ -50,7 +50,7 @@ export const WarningMessages: Record<string, WarningMessage> = {
  * @param extractionResult Extraction result to dump warnings from.
  * @returns Count of emitted warnings in the extraction.
  */
-export function dumpWarnings(extractionResult: ExtractionResult) {
+export function dumpWarnings(extractionResult: ExtractionResults) {
   let warningCount = 0;
 
   for (const [file, { warnings }] of extractionResult.entries()) {

--- a/src/extractor/worker.ts
+++ b/src/extractor/worker.ts
@@ -21,7 +21,7 @@ async function handleJob(args: WorkerParams) {
     loadedExtractor = args.extractor;
     extractor = args.extractor
       ? await loadModule(args.extractor).then((mdl) => mdl.default)
-      : internalExtractor
+      : internalExtractor;
   }
 
   const file = resolve(args.file);
@@ -88,7 +88,7 @@ export async function callWorker(params: WorkerParams) {
   jobQueue.push([params, deferred]);
 
   if (!worker) {
-    worker = createWorker()
+    worker = createWorker();
   }
 
   return deferred.promise;

--- a/src/extractor/worker.ts
+++ b/src/extractor/worker.ts
@@ -2,26 +2,26 @@ import { resolve, extname } from 'path';
 import { Worker, isMainThread, parentPort } from 'worker_threads';
 import { readFile } from 'fs/promises';
 
+// TODO: this solution won't handle new integrations and it will need a slight tweaking before adding new ones
+import internalExtractor from './presets/react';
 import { loadModule } from '../utils/moduleLoader';
 import { type Deferred, createDeferred } from '../utils/deferred';
 
-export type WorkerParams = { extractor: string; file: string };
+export type WorkerParams = { extractor?: string; file: string };
 
 const IS_TS_NODE = extname(__filename) === '.ts';
 
 // --- Worker functions
 
-let loadedExtractor: string;
+let loadedExtractor: string | undefined | symbol = Symbol('unloaded');
 let extractor: Function;
-
-async function loadExtractor(extractorScript: string) {
-  const mdl = await loadModule(extractorScript);
-  extractor = mdl.default;
-}
 
 async function handleJob(args: WorkerParams) {
   if (loadedExtractor !== args.extractor) {
-    await loadExtractor(args.extractor);
+    loadedExtractor = args.extractor;
+    extractor = args.extractor
+      ? await loadModule(args.extractor).then((mdl) => mdl.default)
+      : internalExtractor
   }
 
   const file = resolve(args.file);
@@ -30,10 +30,10 @@ async function handleJob(args: WorkerParams) {
 }
 
 async function workerInit() {
-  parentPort!.on('message', ({ id, params }) => {
+  parentPort!.on('message', (params) => {
     handleJob(params)
-      .then((res) => parentPort!.postMessage({ id: id, data: res }))
-      .catch((e) => parentPort!.postMessage({ id: id, err: e }));
+      .then((res) => parentPort!.postMessage({ data: res }))
+      .catch((e) => parentPort!.postMessage({ err: e }));
   });
 }
 
@@ -42,52 +42,54 @@ if (!isMainThread) workerInit();
 // --- Main thread functions
 
 let worker: Worker;
-let deferredJobsIdPool = 0;
-const deferredJobs = new Map<number, Deferred>();
+const jobQueue: Array<[WorkerParams, Deferred]> = [];
 
-export async function callWorker(params: WorkerParams) {
-  if (!worker) {
-    worker = new Worker(__filename, {
-      // ts-node workaround
-      execArgv: IS_TS_NODE ? ['--require', 'ts-node/register'] : undefined,
-    });
+function createWorker() {
+  const worker = new Worker(__filename, {
+    // ts-node workaround
+    execArgv: IS_TS_NODE ? ['--require', 'ts-node/register'] : undefined,
+  });
 
-    worker.on('error', (e) => {
-      for (const deferred of deferredJobs.values()) {
-        deferred.reject(e);
-      }
+  let timeout: NodeJS.Timeout;
+  let currentDeferred: Deferred;
 
-      deferredJobs.clear();
-    });
+  function workOrDie() {
+    const job = jobQueue.shift();
+    if (!job) {
+      worker.terminate();
+      return;
+    }
 
-    worker.on('message', (msg) => {
-      const deferred = deferredJobs.get(msg.id)!;
-      if (!deferred) {
-        return;
-      }
-
-      if ('data' in msg) {
-        deferred.resolve(msg.data);
-      } else {
-        deferred.reject(msg.err);
-      }
-
-      deferredJobs.delete(msg.id);
-      clearTimeout(timeout);
-    });
-
-    worker.unref();
+    worker.postMessage(job[0]);
+    currentDeferred = job[1];
+    timeout = setTimeout(() => {
+      worker.terminate();
+      currentDeferred.reject(new Error('aborted'));
+    }, 10e3);
   }
 
-  const timeout = setTimeout(() => {
-    worker.terminate();
-    deferred.reject(new Error('aborted'));
-  }, 10e3);
+  worker.on('message', (msg) => {
+    if ('data' in msg) {
+      currentDeferred.resolve(msg.data);
+    } else {
+      currentDeferred.reject(msg.err);
+    }
 
-  const jobId = deferredJobsIdPool++;
+    clearTimeout(timeout);
+    workOrDie();
+  });
+
+  workOrDie();
+  return worker;
+}
+
+export async function callWorker(params: WorkerParams) {
   const deferred = createDeferred();
-  deferredJobs.set(jobId, deferred);
-  worker.postMessage({ id: jobId, params: params });
+  jobQueue.push([params, deferred]);
+
+  if (!worker) {
+    worker = createWorker()
+  }
 
   return deferred.promise;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,12 +21,12 @@ function parseUrlArgument(v: string) {
 }
 
 function parsePath(v: string) {
-  const path = resolve(v)
+  const path = resolve(v);
   if (!existsSync(path)) {
     throw new InvalidArgumentError(`The specified path "${v}" does not exist.`);
   }
 
-  return path
+  return path;
 }
 
 export type BaseOptions = {

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,8 +1,8 @@
 import type Client from './client';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
 import { Option, InvalidArgumentError } from 'commander';
-import { DEFAULT_API_URL, SDKS } from './constants';
-
-const builtinSdks = SDKS.join(', ');
+import { DEFAULT_API_URL } from './constants';
 
 function parseProjectId(v: string) {
   const val = Number(v);
@@ -18,6 +18,15 @@ function parseUrlArgument(v: string) {
   } catch {
     throw new InvalidArgumentError('Malformed URL.');
   }
+}
+
+function parsePath(v: string) {
+  const path = resolve(v)
+  if (!existsSync(path)) {
+    throw new InvalidArgumentError(`The specified path "${v}" does not exist.`);
+  }
+
+  return path
 }
 
 export type BaseOptions = {
@@ -48,5 +57,5 @@ export const API_URL_OPT = new Option(
 
 export const EXTRACTOR = new Option(
   '-e, --extractor <extractor>',
-  `The extractor to use. Either one of the builtins (${builtinSdks}), or a path to a JS/TS file with a custom extractor.`
-).makeOptionMandatory(true);
+  `A path to a custom extractor to use instead of the default one.`
+).argParser(parsePath);

--- a/test/e2e/compare.test.ts
+++ b/test/e2e/compare.test.ts
@@ -13,24 +13,22 @@ const CODE_PROJECT_2_WARNING = `${CODE_PATH}/Test2Warning.tsx`;
 const CODE_PROJECT_3 = `${CODE_PATH}/Test3Mixed.tsx`;
 
 it('says projects are in sync when they do match', async () => {
-  const out = await run([
-    'compare',
-    '--api-key',
-    PROJECT_PAK_2,
-    CODE_PROJECT_2_COMPLETE,
-  ]);
+  const out = await run(
+    ['compare', '--api-key', PROJECT_PAK_2, CODE_PROJECT_2_COMPLETE],
+    undefined,
+    20e3
+  );
 
   expect(out.code).toBe(0);
   expect(out.stdout).toContain('is in sync');
-});
+}, 30e3);
 
 it('detects new keys in code projects', async () => {
-  const out = await run([
-    'compare',
-    '--api-key',
-    PROJECT_PAK_2,
-    CODE_PROJECT_2_ADDED,
-  ]);
+  const out = await run(
+    ['compare', '--api-key', PROJECT_PAK_2, CODE_PROJECT_2_ADDED],
+    undefined,
+    20e3
+  );
 
   expect(out.code).toBe(0);
   expect(out.stdout).toContain('out of sync');
@@ -38,15 +36,14 @@ it('detects new keys in code projects', async () => {
   // Matching \n is important to ensure it properly understood it is not a namespaced string
   expect(out.stdout).toContain('+ mouse-name\n');
   expect(out.stdout).toContain('+ mouse-sound\n');
-});
+}, 30e3);
 
 it('detects keys that no longer exist', async () => {
-  const out = await run([
-    'compare',
-    '--api-key',
-    PROJECT_PAK_2,
-    CODE_PROJECT_2_DELETED,
-  ]);
+  const out = await run(
+    ['compare', '--api-key', PROJECT_PAK_2, CODE_PROJECT_2_DELETED],
+    undefined,
+    20e3
+  );
 
   expect(out.code).toBe(0);
   expect(out.stdout).toContain('out of sync');
@@ -54,15 +51,14 @@ it('detects keys that no longer exist', async () => {
   // Matching \n is important to ensure it properly understood it is not a namespaced string
   expect(out.stdout).toContain('- bird-name\n');
   expect(out.stdout).toContain('- bird-sound\n');
-});
+}, 30e3);
 
 it('handles namespaces properly', async () => {
-  const out = await run([
-    'compare',
-    '--api-key',
-    PROJECT_PAK_3,
-    CODE_PROJECT_3,
-  ]);
+  const out = await run(
+    ['compare', '--api-key', PROJECT_PAK_3, CODE_PROJECT_3],
+    undefined,
+    20e3
+  );
 
   expect(out.code).toBe(0);
   expect(out.stdout).toContain('out of sync');
@@ -72,16 +68,15 @@ it('handles namespaces properly', async () => {
   expect(out.stdout).toContain('- soda (namespace: drinks)');
   expect(out.stdout).toContain('+ table (namespace: furniture)');
   expect(out.stdout).toContain('- table\n');
-});
+}, 30e3);
 
 it('logs emitted warnings to stderr', async () => {
-  const out = await run([
-    'compare',
-    '--api-key',
-    PROJECT_PAK_2,
-    CODE_PROJECT_2_WARNING,
-  ]);
+  const out = await run(
+    ['compare', '--api-key', PROJECT_PAK_2, CODE_PROJECT_2_WARNING],
+    undefined,
+    20e3
+  );
 
   expect(out.code).toBe(0);
   expect(out.stderr).toContain('Warnings were emitted');
-});
+}, 30e3);

--- a/test/e2e/compare.test.ts
+++ b/test/e2e/compare.test.ts
@@ -17,8 +17,6 @@ it('says projects are in sync when they do match', async () => {
     'compare',
     '--api-key',
     PROJECT_PAK_2,
-    '--extractor',
-    'react',
     CODE_PROJECT_2_COMPLETE,
   ]);
 
@@ -31,8 +29,6 @@ it('detects new keys in code projects', async () => {
     'compare',
     '--api-key',
     PROJECT_PAK_2,
-    '--extractor',
-    'react',
     CODE_PROJECT_2_ADDED,
   ]);
 
@@ -49,8 +45,6 @@ it('detects keys that no longer exist', async () => {
     'compare',
     '--api-key',
     PROJECT_PAK_2,
-    '--extractor',
-    'react',
     CODE_PROJECT_2_DELETED,
   ]);
 
@@ -67,8 +61,6 @@ it('handles namespaces properly', async () => {
     'compare',
     '--api-key',
     PROJECT_PAK_3,
-    '--extractor',
-    'react',
     CODE_PROJECT_3,
   ]);
 
@@ -87,8 +79,6 @@ it('logs emitted warnings to stderr', async () => {
     'compare',
     '--api-key',
     PROJECT_PAK_2,
-    '--extractor',
-    'react',
     CODE_PROJECT_2_WARNING,
   ]);
 

--- a/test/e2e/extract.test.ts
+++ b/test/e2e/extract.test.ts
@@ -20,7 +20,7 @@ beforeAll(async () => {
 
 it('prints all the strings and warnings from test project', async () => {
   const out = await run(
-    ['extract', 'print', '--extractor', 'react', CODE_PROJECT_ERR_MATCH],
+    ['extract', 'print', CODE_PROJECT_ERR_MATCH],
     undefined,
     50e3
   );
@@ -38,7 +38,7 @@ it('prints all the strings and warnings from test project', async () => {
 
 it('prints all the checking information from test project (without error)', async () => {
   const out = await run(
-    ['extract', 'check', '--extractor', 'react', CODE_PROJECT_MATCH],
+    ['extract', 'check', CODE_PROJECT_MATCH],
     undefined,
     50e3
   );
@@ -50,7 +50,7 @@ it('prints all the checking information from test project (without error)', asyn
 
 it('prints all the checking information from test project (with error)', async () => {
   const out = await run(
-    ['extract', 'check', '--extractor', 'react', CODE_PROJECT_ERR_MATCH],
+    ['extract', 'check', CODE_PROJECT_ERR_MATCH],
     undefined,
     50e3
   );
@@ -63,7 +63,7 @@ it('prints all the checking information from test project (with error)', async (
 
 it('spits GitHub Workflow Commands when it detects GH Actions env', async () => {
   const out = await run(
-    ['extract', 'check', '--extractor', 'react', CODE_PROJECT_ERR_MATCH],
+    ['extract', 'check', CODE_PROJECT_ERR_MATCH],
     { CI: 'true', GITHUB_ACTIONS: 'true' },
     50e3
   );

--- a/test/e2e/sync.test.ts
+++ b/test/e2e/sync.test.ts
@@ -70,8 +70,6 @@ it('says projects are in sync when they do match', async () => {
     '--yes',
     '--api-key',
     PROJECT_PAK_2,
-    '--extractor',
-    'react',
     CODE_PROJECT_2_COMPLETE,
   ]);
 
@@ -85,8 +83,6 @@ it('creates new keys in code projects', async () => {
     '--yes',
     '--api-key',
     PROJECT_PAK_2,
-    '--extractor',
-    'react',
     CODE_PROJECT_2_ADDED,
   ]);
 
@@ -120,8 +116,6 @@ it('deletes keys that no longer exist', async () => {
     '--remove-unused',
     '--api-key',
     PROJECT_PAK_2,
-    '--extractor',
-    'react',
     CODE_PROJECT_2_DELETED,
   ]);
 
@@ -142,8 +136,6 @@ it('handles namespaces properly', async () => {
     '--yes',
     '--api-key',
     PROJECT_PAK_3,
-    '--extractor',
-    'react',
     CODE_PROJECT_3,
   ]);
 
@@ -172,8 +164,6 @@ it('does a proper backup', async () => {
     '--yes',
     '--api-key',
     PROJECT_PAK_2,
-    '--extractor',
-    'react',
     '--backup',
     TMP_FOLDER,
     CODE_PROJECT_2_DELETED,
@@ -189,8 +179,6 @@ it('logs warnings to stderr and aborts', async () => {
     '--yes',
     '--api-key',
     PROJECT_PAK_2,
-    '--extractor',
-    'react',
     CODE_PROJECT_2_WARNING,
   ]);
 
@@ -205,8 +193,6 @@ it('continues when there are warnings and --continue-on-warning is set', async (
     '--continue-on-warning',
     '--api-key',
     PROJECT_PAK_2,
-    '--extractor',
-    'react',
     CODE_PROJECT_2_WARNING,
   ]);
 

--- a/test/e2e/sync.test.ts
+++ b/test/e2e/sync.test.ts
@@ -75,7 +75,7 @@ it('says projects are in sync when they do match', async () => {
 
   expect(out.code).toBe(0);
   expect(out.stdout).toContain('is in sync');
-});
+}, 30e3);
 
 it('creates new keys in code projects', async () => {
   const out = await run([
@@ -107,17 +107,21 @@ it('creates new keys in code projects', async () => {
       en: 'Squeek',
     },
   });
-});
+}, 30e3);
 
 it('deletes keys that no longer exist', async () => {
-  const out = await run([
-    'sync',
-    '--yes',
-    '--remove-unused',
-    '--api-key',
-    PROJECT_PAK_2,
-    CODE_PROJECT_2_DELETED,
-  ]);
+  const out = await run(
+    [
+      'sync',
+      '--yes',
+      '--remove-unused',
+      '--api-key',
+      PROJECT_PAK_2,
+      CODE_PROJECT_2_DELETED,
+    ],
+    undefined,
+    20e3
+  );
 
   expect(out.code).toBe(0);
   expect(out.stdout).toContain('- 2 strings');
@@ -128,16 +132,14 @@ it('deletes keys that no longer exist', async () => {
   );
 
   expect(keys.page.totalElements).toBe(0);
-});
+}, 30e3);
 
 it('handles namespaces properly', async () => {
-  const out = await run([
-    'sync',
-    '--yes',
-    '--api-key',
-    PROJECT_PAK_3,
-    CODE_PROJECT_3,
-  ]);
+  const out = await run(
+    ['sync', '--yes', '--api-key', PROJECT_PAK_3, CODE_PROJECT_3],
+    undefined,
+    20e3
+  );
 
   expect(out.code).toBe(0);
   expect(out.stdout).toContain('+ 1 string');
@@ -156,46 +158,52 @@ it('handles namespaces properly', async () => {
       en: 'Welcome!',
     },
   });
-});
+}, 30e3);
 
 it('does a proper backup', async () => {
-  const out = await run([
-    'sync',
-    '--yes',
-    '--api-key',
-    PROJECT_PAK_2,
-    '--backup',
-    TMP_FOLDER,
-    CODE_PROJECT_2_DELETED,
-  ]);
+  const out = await run(
+    [
+      'sync',
+      '--yes',
+      '--api-key',
+      PROJECT_PAK_2,
+      '--backup',
+      TMP_FOLDER,
+      CODE_PROJECT_2_DELETED,
+    ],
+    undefined,
+    20e3
+  );
 
   expect(out.code).toBe(0);
   await expect(TMP_FOLDER).toMatchContentsOf(PROJECT_2_DATA);
-});
+}, 30e3);
 
 it('logs warnings to stderr and aborts', async () => {
-  const out = await run([
-    'sync',
-    '--yes',
-    '--api-key',
-    PROJECT_PAK_2,
-    CODE_PROJECT_2_WARNING,
-  ]);
+  const out = await run(
+    ['sync', '--yes', '--api-key', PROJECT_PAK_2, CODE_PROJECT_2_WARNING],
+    undefined,
+    20e3
+  );
 
   expect(out.code).toBe(1);
   expect(out.stderr).toContain('Warnings were emitted');
-});
+}, 30e3);
 
 it('continues when there are warnings and --continue-on-warning is set', async () => {
-  const out = await run([
-    'sync',
-    '--yes',
-    '--continue-on-warning',
-    '--api-key',
-    PROJECT_PAK_2,
-    CODE_PROJECT_2_WARNING,
-  ]);
+  const out = await run(
+    [
+      'sync',
+      '--yes',
+      '--continue-on-warning',
+      '--api-key',
+      PROJECT_PAK_2,
+      CODE_PROJECT_2_WARNING,
+    ],
+    undefined,
+    20e3
+  );
 
   expect(out.code).toBe(0);
   expect(out.stderr).toContain('Warnings were emitted');
-});
+}, 30e3);

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -174,7 +174,6 @@ describe('.tolgeerc', () => {
       apiUrl: new URL('https://app.tolgee.io'),
       projectId: 1337,
       sdk: 'react',
-      extractor: 'react',
     });
   });
 


### PR DESCRIPTION
We can infer the SDK we need to look for, so let's do that instead

**Note**: in the code, the extractor used points to `react.ts`. This is as documented a limitation of the current implementation, and I definitely plan on changing that. The implementation would need to take into account comment-only files which would require a bunch of additional changes.

I plan on solving these issues post initial beta release, among other things. But for now, I went for the simple route.