### PR TITLE
fix: non-tty environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "branches": [
       "main",
       { "name": "next", "channel": "next" },
-      { "name": "prerelease", "channel": "rc", "prerelease": true }
+      { "name": "prerelease", "channel": "rc", "prerelease": "rc" }
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import ansi from 'ansi-colors';
 
 import { getApiKey, savePak, savePat } from './config/credentials';
 import loadTolgeeRc from './config/tolgeerc';
@@ -20,6 +21,8 @@ import CompareCommand from './commands/sync/compare';
 import SyncCommand from './commands/sync/sync';
 
 const NO_KEY_COMMANDS = ['login', 'logout', 'extract'];
+
+ansi.enabled = process.stdout.isTTY;
 
 function topLevelName(command: Command): string {
   return command.parent && command.parent.parent

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -77,7 +77,7 @@ export function error(msg: string) {
 export function loading<T>(comment: string, promise: Promise<T>): Promise<T> {
   if (!process.stdout.isTTY) {
     // Simple stdout without animations
-    process.stdout.write(comment)
+    process.stdout.write(comment);
     promise.then(
       () => process.stdout.write(`   ✓ Success\n`),
       () => process.stdout.write(`   ✗ Failure\n`)

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -75,6 +75,17 @@ export function error(msg: string) {
  * @returns The promise passed in parameter. Useful for decorating without using a buffer variable.
  */
 export function loading<T>(comment: string, promise: Promise<T>): Promise<T> {
+  if (!process.stdout.isTTY) {
+    // Simple stdout without animations
+    process.stdout.write(comment)
+    promise.then(
+      () => process.stdout.write(`   ✓ Success\n`),
+      () => process.stdout.write(`   ✗ Failure\n`)
+    );
+
+    return promise;
+  }
+
   let symbolPosition = 0;
   const interval = setInterval(() => {
     process.stdout.write(`\r${SYMBOLS[symbolPosition]} ${comment}`);

--- a/test/e2e/__internal__/preload.ts
+++ b/test/e2e/__internal__/preload.ts
@@ -10,4 +10,7 @@ import * as constants from '../../../src/constants';
 
 // @ts-expect-error
 constants.CONFIG_PATH = join(tmpdir(), '.tolgee-e2e');
-Object.defineProperty(ansi, 'enabled', { get: () => false, set: () => undefined })
+Object.defineProperty(ansi, 'enabled', {
+  get: () => false,
+  set: () => undefined,
+});

--- a/test/e2e/__internal__/preload.ts
+++ b/test/e2e/__internal__/preload.ts
@@ -5,9 +5,7 @@
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import ansi from 'ansi-colors';
 import * as constants from '../../../src/constants';
 
 // @ts-expect-error
 constants.CONFIG_PATH = join(tmpdir(), '.tolgee-e2e');
-ansi.enabled = false;

--- a/test/e2e/__internal__/preload.ts
+++ b/test/e2e/__internal__/preload.ts
@@ -4,8 +4,10 @@
 
 import { tmpdir } from 'os';
 import { join } from 'path';
+import ansi from 'ansi-colors';
 
 import * as constants from '../../../src/constants';
 
 // @ts-expect-error
 constants.CONFIG_PATH = join(tmpdir(), '.tolgee-e2e');
+Object.defineProperty(ansi, 'enabled', { get: () => false, set: () => undefined })


### PR DESCRIPTION
Disable colors and animations like running mouse.

Also includes semantic-release cfg change to name releases `.rc-x` on `prerelease` branch