### PR TITLE
fix: handle empty strings and namespace-only

### DIFF
--- a/scripts/startDocker.mjs
+++ b/scripts/startDocker.mjs
@@ -3,38 +3,6 @@
 // ---
 
 import { spawn } from 'child_process';
-import { fetch } from 'undici';
-
-async function enforceBaseLanguage() {
-  const { accessToken } = await fetch(
-    'http://localhost:22222/api/public/generatetoken',
-    {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ username: 'admin', password: 'admin' }),
-    }
-  ).then((r) => r.json());
-
-  for (let i = 1; i < 4; i++) {
-    const locales = await fetch(
-      `http://localhost:22222/v2/projects/${i}/languages`,
-      {
-        headers: { authorization: `Bearer ${accessToken}` },
-      }
-    ).then((r) => r.json());
-
-    const enId = locales._embedded.languages.find((l) => l.tag === 'en').id;
-
-    await fetch(`http://localhost:22222/v2/projects/${i}`, {
-      method: 'PUT',
-      headers: {
-        'content-type': 'application/json',
-        authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify({ name: `test${i}`, baseLanguageId: enId }),
-    });
-  }
-}
 
 console.log('Starting Tolgee test container...');
 
@@ -78,10 +46,8 @@ docker.stdout.on('data', (d) => {
   }
 
   if (d.includes('Importing initial project test3')) {
-    enforceBaseLanguage().then(() => {
-      console.log('Test Tolgee server up on port 22222.');
-      process.exit(0);
-    });
+    console.log('Test Tolgee server up on port 22222.');
+    process.exit(0);
   }
 });
 

--- a/scripts/tolgee.env
+++ b/scripts/tolgee.env
@@ -10,3 +10,4 @@ tolgee.internal.controllerEnabled=true
 
 tolgee.import.dir=/mnt/tolgee-import-data
 tolgee.import.createImplicitApiKey=true
+tolgee.import.baseLanguageTag=en

--- a/src/commands/sync/syncUtils.ts
+++ b/src/commands/sync/syncUtils.ts
@@ -58,7 +58,7 @@ export function compareKeys(
   // Added keys
   const namespaces = [...Object.keys(local), NullNamespace] as const;
   for (const namespace of namespaces) {
-    if (local[namespace].size) {
+    if (namespace in local && local[namespace].size) {
       for (const [keyName, defaultValue] of local[namespace].entries()) {
         result.added.push({
           keyName: keyName,

--- a/src/extractor/machines/react.ts
+++ b/src/extractor/machines/react.ts
@@ -648,7 +648,10 @@ export default createMachine<MachineCtx>(
           keyName: ctx.key.keyName || evt.data.keyName,
           defaultValue:
             ctx.key.defaultValue || evt.data.defaultValue || undefined,
-          namespace: evt.data.namespace === '' ? undefined : evt.data.namespace ?? ctx.key.namespace,
+          namespace:
+            evt.data.namespace === ''
+              ? undefined
+              : evt.data.namespace ?? ctx.key.namespace,
           line: ctx.line,
         }),
         warnings: (ctx, evt) => {

--- a/src/extractor/machines/react.ts
+++ b/src/extractor/machines/react.ts
@@ -648,7 +648,7 @@ export default createMachine<MachineCtx>(
           keyName: ctx.key.keyName || evt.data.keyName,
           defaultValue:
             ctx.key.defaultValue || evt.data.defaultValue || undefined,
-          namespace: evt.data.namespace ?? ctx.key.namespace,
+          namespace: evt.data.namespace === '' ? undefined : evt.data.namespace ?? ctx.key.namespace,
           line: ctx.line,
         }),
         warnings: (ctx, evt) => {

--- a/src/extractor/machines/shared/properties.ts
+++ b/src/extractor/machines/shared/properties.ts
@@ -123,6 +123,14 @@ export default createMachine<PropertiesContext>(
       },
       value_string: {
         on: {
+          'punctuation.definition.string.end.ts': {
+            target: 'idle',
+            actions: [ 'storeEmptyPropertyValue', 'clearPropertyType' ],
+          },
+          'punctuation.definition.string.template.end.ts': {
+            target: 'idle',
+            actions: [ 'storeEmptyPropertyValue', 'clearPropertyType' ],
+          },
           '*': [
             {
               target: 'idle',
@@ -225,6 +233,17 @@ export default createMachine<PropertiesContext>(
         namespace: (ctx, evt) =>
           ctx.property === 'ns' ? evt.token : ctx.namespace,
       }),
+      storeEmptyPropertyValue: assign({
+        keyName: (ctx) =>
+          ctx.property === 'key' || ctx.property === 'keyName'
+            ? ''
+            : ctx.keyName,
+        defaultValue: (ctx) =>
+          ctx.property === 'defaultValue' ? '' : ctx.defaultValue,
+        namespace: (ctx) =>
+          ctx.property === 'ns' ? '' : ctx.namespace,
+      }),
+
       markPropertyAsDynamic: assign({
         keyName: (ctx, _evt) =>
           ctx.property === 'key' || ctx.property === 'keyName'

--- a/src/extractor/machines/shared/properties.ts
+++ b/src/extractor/machines/shared/properties.ts
@@ -125,11 +125,11 @@ export default createMachine<PropertiesContext>(
         on: {
           'punctuation.definition.string.end.ts': {
             target: 'idle',
-            actions: [ 'storeEmptyPropertyValue', 'clearPropertyType' ],
+            actions: ['storeEmptyPropertyValue', 'clearPropertyType'],
           },
           'punctuation.definition.string.template.end.ts': {
             target: 'idle',
-            actions: [ 'storeEmptyPropertyValue', 'clearPropertyType' ],
+            actions: ['storeEmptyPropertyValue', 'clearPropertyType'],
           },
           '*': [
             {
@@ -240,8 +240,7 @@ export default createMachine<PropertiesContext>(
             : ctx.keyName,
         defaultValue: (ctx) =>
           ctx.property === 'defaultValue' ? '' : ctx.defaultValue,
-        namespace: (ctx) =>
-          ctx.property === 'ns' ? '' : ctx.namespace,
+        namespace: (ctx) => (ctx.property === 'ns' ? '' : ctx.namespace),
       }),
 
       markPropertyAsDynamic: assign({

--- a/test/unit/extractor/react.test.ts
+++ b/test/unit/extractor/react.test.ts
@@ -97,11 +97,15 @@ describe.each(['js', 'ts', 'jsx', 'tsx'])(
     });
 
     it('extracts the namespace from props', async () => {
-      const expected = [{ keyName: 'key1', namespace: 'ns1', line: 3 }];
+      const expected = [
+        { keyName: 'key1', namespace: 'ns1', line: 3 },
+        { keyName: 'key2', namespace: undefined, line: 4 },
+      ];
 
       const code = `
         import '@tolgee/react'
         React.createElement(T, { keyName: 'key1', ns: 'ns1' })
+        React.createElement(T, { keyName: 'key2', ns: '' })
       `;
 
       const extracted = await extractKeys(code, FILE_NAME);
@@ -437,13 +441,17 @@ describe.each(['js', 'ts', 'jsx', 'tsx'])('useTranslate (.%s)', (ext) => {
   });
 
   it('overrides the specified namespace if one is passed as parameter', async () => {
-    const expected = [{ keyName: 'key1', namespace: 'ns1', line: 5 }];
+    const expected = [
+      { keyName: 'key1', namespace: 'ns1', line: 5 },
+      { keyName: 'key2', namespace: undefined, line: 6 },
+    ];
 
     const code = `
       import '@tolgee/react'
       function Test () {
         const { t } = useTranslate('namespace')
         t('key1', { ns: 'ns1' })
+        t('key2', { ns: '' })
       }
     `;
 

--- a/test/unit/extractor/shared/properties.test.ts
+++ b/test/unit/extractor/shared/properties.test.ts
@@ -154,6 +154,24 @@ describe('Plain JavaScript', () => {
         expect(snapshot.context.defaultValue).toBeNull();
         expect(snapshot.context.namespace).toBe(false);
       });
+
+      it('handles empty strings (ref: #29)', async () => {
+        const tokens = await tokenizer(
+          'const a = { key: "key", ns: "" }',
+          FILE_NAME
+        );
+        for (const token of tokens) {
+          if (!machine.getSnapshot().done) {
+            machine.send(token);
+          }
+        }
+
+        const snapshot = machine.getSnapshot();
+        expect(snapshot.done).toBe(true);
+        expect(snapshot.context.keyName).toBe('key');
+        expect(snapshot.context.defaultValue).toBeNull();
+        expect(snapshot.context.namespace).toBe('');
+      });
     });
   });
 
@@ -403,6 +421,24 @@ describe('JSX', () => {
         expect(snapshot.context.keyName).toBe(false);
         expect(snapshot.context.defaultValue).toBeNull();
         expect(snapshot.context.namespace).toBe(false);
+      });
+
+      it('handles empty strings (ref: #29)', async () => {
+        const tokens = await tokenizer(
+          '<T keyName ns="" />',
+          FILE_NAME
+        );
+        for (const token of tokens) {
+          if (!machine.getSnapshot().done) {
+            machine.send(token);
+          }
+        }
+
+        const snapshot = machine.getSnapshot();
+        expect(snapshot.done).toBe(true);
+        expect(snapshot.context.keyName).toBe(false);
+        expect(snapshot.context.defaultValue).toBeNull();
+        expect(snapshot.context.namespace).toBe('');
       });
     });
   });

--- a/test/unit/extractor/shared/properties.test.ts
+++ b/test/unit/extractor/shared/properties.test.ts
@@ -424,10 +424,7 @@ describe('JSX', () => {
       });
 
       it('handles empty strings (ref: #29)', async () => {
-        const tokens = await tokenizer(
-          '<T keyName ns="" />',
-          FILE_NAME
-        );
+        const tokens = await tokenizer('<T keyName ns="" />', FILE_NAME);
         for (const token of tokens) {
           if (!machine.getSnapshot().done) {
             machine.send(token);


### PR DESCRIPTION
#30 was actually unrelated to the presence of quotes but rather was related to projects containing only namespaced keys. `NullNamespace` was always checked but was not present in this scenario, causing an error.

closes #29
closes #30