### PR TITLE
fix: increase req timeout for export and import

### DIFF
--- a/src/client/export.ts
+++ b/src/client/export.ts
@@ -20,6 +20,8 @@ export default class ExportClient {
       method: 'POST',
       path: `${this.requester.projectUrl}/export`,
       body: { ...req, zip: true },
+      headersTimeout: 300,
+      bodyTimeout: 300,
     });
   }
 
@@ -30,6 +32,8 @@ export default class ExportClient {
       method: 'POST',
       path: `${this.requester.projectUrl}/export`,
       body: { ...req, zip: false },
+      headersTimeout: 300,
+      bodyTimeout: 300,
     });
   }
 }

--- a/src/client/import.ts
+++ b/src/client/import.ts
@@ -55,6 +55,8 @@ export default class ImportClient {
       method: 'PUT',
       path: `${this.requester.projectUrl}/import/apply`,
       query: { forceMode: req?.forceMode },
+      headersTimeout: 300,
+      bodyTimeout: 300,
     });
   }
 
@@ -71,7 +73,7 @@ export default class ImportClient {
     try {
       await this.deleteImport();
     } catch (e) {
-      if (e instanceof HttpError && e.response.status === 404) return;
+      if (e instanceof HttpError && e.response.statusCode === 404) return;
       throw e;
     }
   }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -21,7 +21,7 @@ async function loginHandler(this: Command, key: string) {
   try {
     keyInfo = await RestClient.getApiKeyInformation(opts.apiUrl, key);
   } catch (e) {
-    if (e instanceof HttpError && e.response.status === 401) {
+    if (e instanceof HttpError && e.response.statusCode === 401) {
       error("Couldn't log in: the API key you provided is invalid.");
       process.exit(1);
     }

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -39,8 +39,8 @@ async function pullHandler(this: Command, path: string) {
     await loading('Extracting strings...', unzipBuffer(zipBlob, path));
     success('Done!');
   } catch (e) {
-    if (e instanceof HttpError && e.response.status === 400) {
-      const res: any = await e.response.json();
+    if (e instanceof HttpError && e.response.statusCode === 400) {
+      const res: any = await e.response.body.json();
       error(
         `Please check if your parameters, including namespaces, are configured correctly. Tolgee responded with: ${res.code}`
       );

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -114,7 +114,7 @@ async function applyImport(client: Client) {
   try {
     await loading('Applying changes...', client.import.applyImport());
   } catch (e) {
-    if (e instanceof HttpError && e.response.status === 400) {
+    if (e instanceof HttpError && e.response.statusCode === 400) {
       error(
         "Some of the imported languages weren't recognized. Please create a language with corresponding tag in the Tolgee Platform."
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,11 +158,11 @@ async function loadConfig() {
 
 async function handleHttpError(e: HttpError) {
   error('An error occurred while requesting the API.');
-  error(`${e.request.method} ${e.request.url}`);
+  error(`${e.request.method} ${e.request.path}`);
   error(e.getErrorText());
 
   // Remove token from store if necessary
-  if (e.response.status === 401) {
+  if (e.response.statusCode === 401) {
     const removeFn = program.getOptionValue('_removeApiKeyFromStore');
     if (removeFn) {
       info('Removing the API key from the authentication store.');
@@ -177,7 +177,7 @@ async function handleHttpError(e: HttpError) {
     // catastrophic failure) which means the output is completely unpredictable. While some errors are
     // formatted by the Tolgee server, reality is there's a huge chance the 5xx error hasn't been raised
     // by Tolgee's error handler.
-    const res = await e.response.text();
+    const res = await e.response.body.text();
     debug(`Server response:\n\n---\n${res}\n---`);
   }
 }


### PR DESCRIPTION
Users were having troubles applying large endpoints as the backend took more than the default timeout to respond