### PR TITLE
feat: support multiple glob patterns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -1,0 +1,6 @@
+import { Argument } from 'commander';
+
+export const FILE_PATTERNS = new Argument(
+  '<patterns...>',
+  'File glob patterns to include (hint: make sure to escape it in quotes, or your shell might attempt to unroll some tokens like *)'
+);

--- a/src/commands/extract/check.ts
+++ b/src/commands/extract/check.ts
@@ -8,14 +8,15 @@ import {
   emitGitHubWarning,
 } from '../../extractor/warnings.js';
 import { loading } from '../../utils/logger.js';
+import { FILE_PATTERNS } from '../../arguments.js';
 
 type ExtractLintOptions = BaseExtractOptions;
 
-async function lintHandler(this: Command, filesPattern: string) {
+async function lintHandler(this: Command, filesPatterns: string[]) {
   const opts: ExtractLintOptions = this.optsWithGlobals();
   const extracted = await loading(
     'Analyzing code...',
-    extractKeysOfFiles(filesPattern, opts.extractor)
+    extractKeysOfFiles(filesPatterns, opts.extractor)
   );
 
   let warningCount = 0;
@@ -59,8 +60,5 @@ export default new Command('check')
   .description(
     'Checks if the keys can be extracted automatically, and reports problems if any'
   )
-  .argument(
-    '<pattern>',
-    'File pattern to include (hint: make sure to escape it in quotes, or your shell might attempt to unroll some tokens like *)'
-  )
+  .addArgument(FILE_PATTERNS)
   .action(lintHandler);

--- a/src/commands/extract/print.ts
+++ b/src/commands/extract/print.ts
@@ -5,14 +5,15 @@ import { Command } from 'commander';
 import { extractKeysOfFiles } from '../../extractor/runner.js';
 import { WarningMessages } from '../../extractor/warnings.js';
 import { loading } from '../../utils/logger.js';
+import { FILE_PATTERNS } from '../../arguments.js';
 
 type ExtractPrintOptions = BaseExtractOptions;
 
-async function printHandler(this: Command, filesPattern: string) {
+async function printHandler(this: Command, filesPatterns: string[]) {
   const opts: ExtractPrintOptions = this.optsWithGlobals();
   const extracted = await loading(
     'Analyzing code...',
-    extractKeysOfFiles(filesPattern, opts.extractor)
+    extractKeysOfFiles(filesPatterns, opts.extractor)
   );
 
   let warningCount = 0;
@@ -67,8 +68,5 @@ async function printHandler(this: Command, filesPattern: string) {
 
 export default new Command('print')
   .description('Prints extracted data to the console')
-  .argument(
-    '<pattern>',
-    'File glob pattern to include (hint: make sure to escape it in quotes, or your shell might attempt to unroll some tokens like *)'
-  )
+  .addArgument(FILE_PATTERNS)
   .action(printHandler);

--- a/src/commands/sync/compare.ts
+++ b/src/commands/sync/compare.ts
@@ -10,17 +10,18 @@ import {
 import { dumpWarnings } from '../../extractor/warnings.js';
 import { EXTRACTOR } from '../../options.js';
 import { loading } from '../../utils/logger.js';
+import { FILE_PATTERNS } from '../../arguments.js';
 
 type Options = BaseOptions & {
   extractor: string;
 };
 
-async function compareHandler(this: Command, pattern: string) {
+async function compareHandler(this: Command, filesPatterns: string[]) {
   const opts: Options = this.optsWithGlobals();
 
   const rawKeys = await loading(
     'Analyzing code...',
-    extractKeysOfFiles(pattern, opts.extractor)
+    extractKeysOfFiles(filesPatterns, opts.extractor)
   );
   dumpWarnings(rawKeys);
 
@@ -68,9 +69,6 @@ export default new Command()
   .description(
     'Compares the keys in your code project and in the Tolgee project.'
   )
-  .argument(
-    '<pattern>',
-    'File pattern to include (hint: make sure to escape it in quotes, or your shell might attempt to unroll some tokens like *)'
-  )
+  .addArgument(FILE_PATTERNS)
   .addOption(EXTRACTOR)
   .action(compareHandler);

--- a/src/commands/sync/sync.ts
+++ b/src/commands/sync/sync.ts
@@ -16,6 +16,7 @@ import { askBoolean } from '../../utils/ask.js';
 import { loading, error } from '../../utils/logger.js';
 
 import { EXTRACTOR } from '../../options.js';
+import { FILE_PATTERNS } from '../../arguments.js';
 
 type Options = BaseOptions & {
   extractor: string;
@@ -59,12 +60,12 @@ async function askForConfirmation(
   }
 }
 
-async function syncHandler(this: Command, pattern: string) {
+async function syncHandler(this: Command, filesPatterns: string[]) {
   const opts: Options = this.optsWithGlobals();
 
   const rawKeys = await loading(
     'Analyzing code...',
-    extractKeysOfFiles(pattern, opts.extractor)
+    extractKeysOfFiles(filesPatterns, opts.extractor)
   );
   const warnCount = dumpWarnings(rawKeys);
   if (!opts.continueOnWarning && warnCount) {
@@ -174,10 +175,7 @@ export default new Command()
   .description(
     'Synchronizes the keys in your code project and in the Tolgee project, by creating missing keys and optionally deleting unused ones. For a dry-run, use `tolgee compare`.'
   )
-  .argument(
-    '<pattern>',
-    'File pattern to include (hint: make sure to escape it in quotes, or your shell might attempt to unroll some tokens like *)'
-  )
+  .addArgument(FILE_PATTERNS)
   .addOption(EXTRACTOR)
   .option(
     '-B, --backup <path>',

--- a/src/extractor/runner.ts
+++ b/src/extractor/runner.ts
@@ -18,10 +18,10 @@ export async function extractKeysFromFile(file: string, extractor?: string) {
 }
 
 export async function extractKeysOfFiles(
-  filesPattern: string,
+  filesPatterns: string[],
   extractor: string
 ) {
-  const files = await glob(filesPattern, { nodir: true });
+  const files = await glob(filesPatterns, { nodir: true });
   const result: ExtractionResults = new Map();
 
   await Promise.all(


### PR DESCRIPTION
Closes #68 

The main change is that the pattern argument is now a [variadic option](https://github.com/tj/commander.js?tab=readme-ov-file#variadic-option).

To remove code duplication I moved this argument to it's own file `arguments.ts` and imported it where it was used. I also renamed it from `pattern` to `patterns` to indicate, that this argument is now an array.

The `.editorconfig` and `.gitattribute` files are just for the convenience of Windows users, because otherwise prettier can constantly show line ending errors for us when we work with the code.