### PR TITLE
build: make build and test scripts cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "tolgee": "./dist/index.js"
   },
   "scripts": {
-    "build": "rimraf dist dist-types && tsc && cp dist-types/extractor/index.d.ts extractor.d.ts",
+    "build": "rimraf dist dist-types && tsc && node scripts/copyExtractorTypes.mjs",
     "test": "npm run test:unit && npm run test:e2e && npm run test:package",
     "test:unit": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest -c jest.unit.config.ts",
     "pretest:e2e": "npm run build && npm run tolgee:start",

--- a/scripts/copyExtractorTypes.mjs
+++ b/scripts/copyExtractorTypes.mjs
@@ -1,0 +1,8 @@
+import { copyFile } from 'fs/promises';
+import path from 'path';
+
+const cwd = process.cwd();
+const sourcePath = path.join(cwd, 'dist-types/extractor/index.d.ts');
+const destinationPath = path.join(cwd, 'extractor.d.ts');
+
+await copyFile(sourcePath, destinationPath);

--- a/scripts/startDocker.js
+++ b/scripts/startDocker.js
@@ -3,9 +3,18 @@
 // ---
 
 import { fileURLToPath } from 'url';
-import { spawn } from 'child_process';
+import { spawn, execSync } from 'child_process';
 
-console.log('Starting Tolgee test container...');
+try {
+  execSync('docker info', { stdio: 'ignore' });
+} catch {
+  console.error(
+    "This script uses docker, and it isn't running - please start docker and try again!"
+  );
+  process.exit(1);
+}
+
+console.log('Starting Tolgee test container. This might take a while...');
 
 let stderr = '';
 

--- a/scripts/validatePackage.js
+++ b/scripts/validatePackage.js
@@ -2,13 +2,17 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { rmSync } from 'fs';
 import { mkdir, writeFile, rm } from 'fs/promises';
+import { readFileSync } from 'fs';
 import { randomUUID } from 'crypto';
 import { execSync } from 'child_process';
 import { ok } from 'assert';
 
+const PACKAGE_JSON_PATH = new URL('../package.json', import.meta.url);
+const PACKAGE_JSON = readFileSync(PACKAGE_JSON_PATH, 'utf8');
+const VERSION = JSON.parse(PACKAGE_JSON).version;
 const WORK_DIRECTORY = join(tmpdir(), randomUUID());
 const PACKAGE_DEST = join(WORK_DIRECTORY, 'package');
-const TARBALL_DEST = join(WORK_DIRECTORY, 'tolgee-cli.tgz');
+const TARBALL_DEST = join(WORK_DIRECTORY, `tolgee-cli-${VERSION}.tgz`);
 
 function execOrError(cmd, opts) {
   try {
@@ -34,11 +38,9 @@ await mkdir(PACKAGE_DEST, { recursive: true });
 console.log('PREP: building the package');
 execOrError('npm run build');
 
-// Create a tarball, and move it to a known path (drop the version from the pkg name)
+// Create a tarball
 console.log('PREP: packaging');
 execOrError(`npm pack --pack-destination ${JSON.stringify(WORK_DIRECTORY)}`);
-const moveCommand = process.platform === 'win32' ? 'move' : 'mv';
-execOrError(`${moveCommand} *.tgz tolgee-cli.tgz`, { cwd: WORK_DIRECTORY });
 
 // Create a test npm project and install CLI from tarball
 console.log('PREP: preparing test package');

--- a/scripts/validatePackage.js
+++ b/scripts/validatePackage.js
@@ -37,7 +37,8 @@ execOrError('npm run build');
 // Create a tarball, and move it to a known path (drop the version from the pkg name)
 console.log('PREP: packaging');
 execOrError(`npm pack --pack-destination ${JSON.stringify(WORK_DIRECTORY)}`);
-execOrError('mv *.tgz tolgee-cli.tgz', { cwd: WORK_DIRECTORY });
+const moveCommand = process.platform === 'win32' ? 'move' : 'mv';
+execOrError(`${moveCommand} *.tgz tolgee-cli.tgz`, { cwd: WORK_DIRECTORY });
 
 // Create a test npm project and install CLI from tarball
 console.log('PREP: preparing test package');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "ESNext",
+    "module": "NodeNext",
     /* Specify what module code is generated. */
     "rootDir": "./src",
     /* Specify the root folder within your source files. */


### PR DESCRIPTION
The current `build` and `test:package` commands do not work on Windows, because they use the `cp` and `mv` command.

This PR fixes both of their usages:
- instead of `cp`, the build script now copies files with Node.js's `copyFile()`
- the `validatePackage` script checks if it runs on Windows and uses the `move` command instead of `mv` if it is.