### PR TITLE
fix: "languages" pull config from .tolgeerc

### DIFF
--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -80,7 +80,7 @@ export default (config: Schema) =>
       new Option(
         '-l, --languages <languages...>',
         'List of languages to pull. Leave unspecified to export them all'
-      ).default(config.pull?.languagess)
+      ).default(config.pull?.languages)
     )
     .addOption(
       new Option(


### PR DESCRIPTION
Pull config item "languages" is not accessed correctly and is thus not respected.
Currently default value (all) is always used regardles of .tolgeerc content.