### PR TITLE
feat: New sync option "default namespace"

### DIFF
--- a/src/commands/sync/sync.ts
+++ b/src/commands/sync/sync.ts
@@ -22,6 +22,7 @@ import {
 
 type Options = BaseOptions & {
   backup?: string;
+  defaultNamespace?: string;
   removeUnused?: boolean;
   continueOnWarning?: boolean;
   yes?: boolean;
@@ -76,7 +77,7 @@ const syncHandler = (config: Schema) =>
 
     const rawKeys = await loading(
       'Analyzing code...',
-      extractKeysOfFiles(patterns, opts.extractor)
+      extractKeysOfFiles(patterns, opts.extractor, opts.defaultNamespace)
     );
     const warnCount = dumpWarnings(rawKeys);
     if (!opts.continueOnWarning && warnCount) {
@@ -218,6 +219,10 @@ export default (config: Schema) =>
     .option(
       '-B, --backup <path>',
       'Store translation files backup (only translation files, not states, comments, tags, etc.). If something goes wrong, the backup can be used to restore the project to its previous state.'
+    )
+    .option(
+      '-dn, --default-namespace <namespace>',
+      'Use the specified namespace for keys with undetected namespace. Without this parameter, keys with undetected namespace will assume no namespace.'
     )
     .option(
       '--continue-on-warning',

--- a/src/extractor/runner.ts
+++ b/src/extractor/runner.ts
@@ -19,7 +19,8 @@ export async function extractKeysFromFile(file: string, extractor?: string) {
 
 export async function extractKeysOfFiles(
   filesPatterns: string[],
-  extractor: string | undefined
+  extractor: string | undefined,
+  defaultNamespace?: string | undefined
 ) {
   const files = await glob(filesPatterns, { nodir: true });
   const result: ExtractionResults = new Map();
@@ -27,6 +28,11 @@ export async function extractKeysOfFiles(
   await Promise.all(
     files.map(async (file) => {
       const keys = await extractKeysFromFile(file, extractor);
+      for (const key of keys.keys) {
+        if (!key.namespace && defaultNamespace) {
+          key.namespace = defaultNamespace;
+        }
+      }
       result.set(file, keys);
     })
   );


### PR DESCRIPTION
Re-make of #77 for v2.0 - but this time, only the "default namespace" part.
My use case: monorepo where each subfolder project has its unique Tolgee namespace - which is difficult for the CLI to auto-detect.