### PR TITLE
fix: adapt to scoped namespaces in import

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -88,7 +88,7 @@
           }
         },
         "removeOtherKeys": {
-          "description": "Remove keys which are not present in the import (within namespaces imported namespaces).",
+          "description": "Remove keys which are not present in the import (within imported namespaces).",
           "type": "boolean"
         }
       }

--- a/schema.json
+++ b/schema.json
@@ -88,7 +88,7 @@
           }
         },
         "removeOtherKeys": {
-          "description": "Remove keys which are not present in the import.",
+          "description": "Remove keys which are not present in the import (within namespaces imported namespaces).",
           "type": "boolean"
         }
       }

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -296,7 +296,7 @@ export default (config: Schema) =>
     .addOption(
       new Option(
         '--remove-other-keys',
-        'Remove keys which are not present in the import.'
+        'Remove keys which are not present in the import (within imported namespaces).'
       ).default(config.push?.removeOtherKeys)
     )
     .action(pushHandler(config));

--- a/test/e2e/push.test.ts
+++ b/test/e2e/push.test.ts
@@ -311,7 +311,7 @@ describe('project 3', () => {
 
     const stored = tolgeeDataToDict(keys.data);
 
-    // namespace not supposed to be influenced "food" is not influenced
+    // Keys in the "food" namespace should not be removed
     expect(Object.keys(stored)).toEqual([
       'table',
       'chair',
@@ -358,6 +358,7 @@ describe('project 3', () => {
 
     const stored = tolgeeDataToDict(keys.data);
 
+    // Keys in the "food" namespace should not be removed
     expect(Object.keys(stored)).toEqual([
       'table',
       'chair',

--- a/test/e2e/push.test.ts
+++ b/test/e2e/push.test.ts
@@ -311,12 +311,16 @@ describe('project 3', () => {
 
     const stored = tolgeeDataToDict(keys.data);
 
+    // namespace not supposed to be influenced "food" is not influenced
     expect(Object.keys(stored)).toEqual([
       'table',
       'chair',
       'plate',
       'fork',
       'water',
+      'salad',
+      'tomato',
+      'onions',
     ]);
   });
 
@@ -360,6 +364,9 @@ describe('project 3', () => {
       'plate',
       'fork',
       'water',
+      'salad',
+      'tomato',
+      'onions',
     ]);
   });
 });


### PR DESCRIPTION
Actual fix was done on the backend https://github.com/tolgee/tolgee-platform/pull/3093

Closes #175 

## Summary by CodeRabbit

- **Documentation**
  - Updated the description of the "removeOtherKeys" option for improved clarity about its effect within imported namespaces.

- **Tests**
  - Enhanced test cases to verify that specific keys remain after performing a push operation with key removal, ensuring correct behavior in affected namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the description of the "removeOtherKeys" option for improved clarity about its effect within imported namespaces.

- **Tests**
  - Enhanced test cases to verify that specific keys remain after performing a push operation with key removal, ensuring correct behavior in affected namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->