### PR TITLE
fix: branch listing shows all active branches

### DIFF
--- a/src/utils/branch.ts
+++ b/src/utils/branch.ts
@@ -13,7 +13,7 @@ export async function fetchBranches(cmd: BaseOptions) {
   const loadable = await cmd.client.GET('/v2/projects/{projectId}/branches', {
     params: {
       path: { projectId: cmd.client.getProjectId() },
-      query: { size: 10000, activeOnly: true },
+      query: { size: 10000 },
     },
   });
   handleLoadableError(loadable);
@@ -21,8 +21,6 @@ export async function fetchBranches(cmd: BaseOptions) {
 }
 
 export function listBranches(branches: components['schemas']['BranchModel'][]) {
-  branches = branches.filter((b) => !b.merge || !b.merge.mergedAt);
-
   if (!branches.length) {
     success('No branches found.');
     return;


### PR DESCRIPTION
## Summary

- Remove client-side filter in `listBranches` that was excluding branches with a `mergedAt` date — all branches returned by the endpoint are now shown
- Remove `activeOnly` query parameter from `fetchBranches` so the endpoint returns all branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated branch listing to display all branches, including previously merged branches.
  * Modified branch fetching to retrieve all available branches without exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->