### PR TITLE
fix: preserve negation prefix when resolving config patterns

### DIFF
--- a/src/config/tolgeerc.ts
+++ b/src/config/tolgeerc.ts
@@ -60,9 +60,12 @@ function parseConfig(input: Schema, configDir: string) {
 
   // convert relative paths in config to absolute
   if (rc.patterns !== undefined) {
-    rc.patterns = rc.patterns.map((pattern: string) =>
-      resolve(configDir, pattern).replace(/\\/g, '/')
-    );
+    rc.patterns = rc.patterns.map((pattern: string) => {
+      const isNegated = pattern.startsWith('!');
+      const raw = isNegated ? pattern.slice(1) : pattern;
+      const resolved = resolve(configDir, raw).replace(/\\/g, '/');
+      return isNegated ? `!${resolved}` : resolved;
+    });
   }
 
   // convert relative paths in config to absolute

--- a/test/__fixtures__/validTolgeeRc/withNegationPattern.json
+++ b/test/__fixtures__/validTolgeeRc/withNegationPattern.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../schema.json",
+  "apiUrl": "https://app.tolgee.io",
+  "projectId": 1337,
+  "patterns": ["./src/**/*.tsx", "!./src/excluded.tsx"]
+}

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -84,6 +84,19 @@ describe('.tolgeerc', () => {
     }
   });
 
+  it('preserves negation prefix when resolving patterns', async () => {
+    const path = fileURLToPath(
+      new URL('./validTolgeeRc/withNegationPattern.json', FIXTURES_PATH)
+    );
+
+    const cfg = (await loadTolgeeRc(path))!;
+
+    expect(cfg.patterns!.some((p) => p.startsWith('!'))).toBe(true);
+    for (const pattern of cfg.patterns!) {
+      expect(pattern.lastIndexOf('!')).toBeLessThanOrEqual(0);
+    }
+  });
+
   it('converts projectId to number', async () => {
     const path = fileURLToPath(
       new URL('./validTolgeeRc/withProjectIdString.json', FIXTURES_PATH)


### PR DESCRIPTION
Negation glob patterns (e.g. `!./src/excluded.tsx`) in `.tolgeerc` config were broken - `resolve()` included the `!` as part of the path, producing `/abs/path/!./src/excluded.tsx` instead of `!/abs/path/src/excluded.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Negation pattern support: Configuration patterns now support the "!" prefix to exclude specific files from matching. This provides users with enhanced granular control over pattern matching behavior, enabling them to define comprehensive patterns while easily excluding specific files that should not be matched or processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->