### PR TITLE
feat(extractor): resolve const namespace identifiers and NS.KEY member access

### DIFF
--- a/src/extractor/extractor.ts
+++ b/src/extractor/extractor.ts
@@ -48,7 +48,6 @@ export async function extractTreeAndReport(
     tokens,
     onAccept,
     options,
-    code,
   });
 
   if (debug) {

--- a/src/extractor/extractor.ts
+++ b/src/extractor/extractor.ts
@@ -48,6 +48,7 @@ export async function extractTreeAndReport(
     tokens,
     onAccept,
     options,
+    code,
   });
 
   if (debug) {

--- a/src/extractor/parser/extractConstants.ts
+++ b/src/extractor/parser/extractConstants.ts
@@ -27,171 +27,205 @@ import { Token } from './types.js';
  * Walking the already-merged token stream (rather than running regex on
  * the raw source) means strings, comments, template literals and block
  * delimiters are already correctly classified by TextMate. In particular
- * the `funcDepth` counter below ensures we only capture declarations at
- * module top level — a `const X = '...'` nested inside a function body
- * or branch is invisible to the capture, which matches the visibility
- * the consumer of the identifier would have.
+ * the `funcDepth` counter ensures we only capture declarations at module
+ * top level — a `const X = '...'` nested inside a function body or
+ * branch is invisible to the capture, which matches the visibility the
+ * consumer of the identifier would have.
  */
-export function extractConstants(
-  tokens: ReadonlyArray<Token<string | undefined>>
-): Map<string, string> {
-  const result = new Map<string, string>();
 
-  type State =
-    | 'Idle'
-    | 'AfterConst'
-    | 'AfterName'
-    | 'InTypeAnnotation'
-    | 'AfterAssign'
-    | 'InObjectBody'
-    | 'InObjectAfterKey'
-    | 'InObjectAfterColon';
+type State =
+  | 'Idle'
+  | 'AfterConst'
+  | 'AfterName'
+  | 'InTypeAnnotation'
+  | 'AfterAssign'
+  | 'InObjectBody'
+  | 'InObjectAfterKey'
+  | 'InObjectAfterColon';
 
-  let state: State = 'Idle';
+type AnyToken = Token<string | undefined>;
+
+type Context = {
+  result: Map<string, string>;
+  state: State;
   // Depth of block/control-flow bodies we're currently inside. While
   // > 0, top-level const-detection is suspended; only block.begin/end
   // are tracked so we know when we resurface.
-  let funcDepth = 0;
+  funcDepth: number;
   // Depth of the object literal currently being captured (1 = top of
   // the object body). Tracked separately from funcDepth so a nested
   // object literal value abandons capture without leaking depth.
-  let objectDepth = 0;
-  let captureName = '';
-  let captureProps: Array<{ key: string; value: string }> = [];
-  let currentKey = '';
-  let abandonedObject = false;
+  objectDepth: number;
+  captureName: string;
+  captureProps: Array<{ key: string; value: string }>;
+  currentKey: string;
+  // Set when a nested block.begin is seen during object capture; any
+  // properties already collected for this capture are discarded.
+  abandonedObject: boolean;
+};
 
-  const reset = () => {
-    state = 'Idle';
-    captureProps = [];
-    captureName = '';
-    currentKey = '';
-    abandonedObject = false;
+function createContext(): Context {
+  return {
+    result: new Map(),
+    state: 'Idle',
+    funcDepth: 0,
+    objectDepth: 0,
+    captureName: '',
+    captureProps: [],
+    currentKey: '',
+    abandonedObject: false,
   };
+}
+
+function resetCapture(ctx: Context): void {
+  ctx.state = 'Idle';
+  ctx.captureProps = [];
+  ctx.captureName = '';
+  ctx.currentKey = '';
+  ctx.abandonedObject = false;
+}
+
+function finalizeObjectCapture(ctx: Context): void {
+  if (!ctx.abandonedObject) {
+    for (const { key, value } of ctx.captureProps) {
+      const composed = `${ctx.captureName}.${key}`;
+      if (!ctx.result.has(composed)) {
+        ctx.result.set(composed, value);
+      }
+    }
+  }
+  resetCapture(ctx);
+}
+
+/** Track block depth inside a function body / control-flow block. */
+function stepInFunctionBody(ctx: Context, token: AnyToken): void {
+  if (token.customType === 'block.begin') ctx.funcDepth++;
+  else if (token.customType === 'block.end') ctx.funcDepth--;
+}
+
+/** Walk the body of a `const NS = { ... }` capture. */
+function stepInObjectBody(ctx: Context, token: AnyToken): void {
+  const c = token.customType;
+
+  if (c === 'block.begin') {
+    ctx.objectDepth++;
+    ctx.abandonedObject = true;
+    return;
+  }
+  if (c === 'block.end') {
+    ctx.objectDepth--;
+    if (ctx.objectDepth === 0) {
+      finalizeObjectCapture(ctx);
+    }
+    return;
+  }
+  if (ctx.abandonedObject) return;
+
+  switch (ctx.state) {
+    case 'InObjectBody':
+      if (c === 'object.key') {
+        ctx.currentKey = token.token;
+        ctx.state = 'InObjectAfterKey';
+      }
+      break;
+    case 'InObjectAfterKey':
+      if (c === 'acessor.doublecolon') {
+        ctx.state = 'InObjectAfterColon';
+      } else {
+        ctx.state = 'InObjectBody';
+      }
+      break;
+    case 'InObjectAfterColon':
+      if (c === 'string') {
+        ctx.captureProps.push({ key: ctx.currentKey, value: token.token });
+      }
+      ctx.state = 'InObjectBody';
+      break;
+  }
+}
+
+/** Module-top-level state machine — the only place captures originate. */
+function stepAtTopLevel(ctx: Context, token: AnyToken): void {
+  const c = token.customType;
+
+  switch (ctx.state) {
+    case 'Idle':
+      if (c === 'block.begin') {
+        ctx.funcDepth = 1;
+      } else if (!c && token.token === 'const') {
+        ctx.state = 'AfterConst';
+      }
+      // `export` and other prefixes simply stay in Idle until the
+      // following `const` token is seen.
+      break;
+
+    case 'AfterConst':
+      if (c === 'variable') {
+        ctx.captureName = token.token;
+        ctx.state = 'AfterName';
+      } else if (c === 'block.begin' || c === 'list.begin') {
+        // Destructure pattern like `const { x } = ...` — skip until
+        // the destructure pattern closes by piggybacking on funcDepth.
+        ctx.funcDepth = 1;
+        ctx.state = 'Idle';
+      } else {
+        ctx.state = 'Idle';
+      }
+      break;
+
+    case 'AfterName':
+      if (c === 'operator.assignment') {
+        ctx.state = 'AfterAssign';
+      } else if (c === 'acessor.doublecolon') {
+        ctx.state = 'InTypeAnnotation';
+      } else {
+        ctx.state = 'Idle';
+      }
+      break;
+
+    case 'InTypeAnnotation':
+      if (c === 'operator.assignment') {
+        ctx.state = 'AfterAssign';
+      } else if (c === 'block.begin') {
+        // Type-level block like `const X: { foo: 1 } = ...`. Bail out
+        // of this declaration; the rest is content we can't reason
+        // about with this state machine.
+        ctx.funcDepth = 1;
+        ctx.state = 'Idle';
+      }
+      // Otherwise just skip over the type tokens.
+      break;
+
+    case 'AfterAssign':
+      if (c === 'string') {
+        if (!ctx.result.has(ctx.captureName)) {
+          ctx.result.set(ctx.captureName, token.token);
+        }
+        resetCapture(ctx);
+      } else if (c === 'block.begin') {
+        ctx.objectDepth = 1;
+        ctx.state = 'InObjectBody';
+      } else {
+        ctx.state = 'Idle';
+      }
+      break;
+  }
+}
+
+export function extractConstants(
+  tokens: ReadonlyArray<AnyToken>
+): Map<string, string> {
+  const ctx = createContext();
 
   for (const token of tokens) {
-    const c = token.customType;
-
-    // Inside a function body / control-flow block — nothing here is at
-    // module top level so skip until we resurface.
-    if (funcDepth > 0) {
-      if (c === 'block.begin') funcDepth++;
-      else if (c === 'block.end') funcDepth--;
-      continue;
-    }
-
-    // Object literal capture — has its own depth counter.
-    if (objectDepth > 0) {
-      if (c === 'block.begin') {
-        objectDepth++;
-        abandonedObject = true;
-        continue;
-      }
-      if (c === 'block.end') {
-        objectDepth--;
-        if (objectDepth === 0) {
-          if (!abandonedObject) {
-            for (const { key, value } of captureProps) {
-              const composed = `${captureName}.${key}`;
-              if (!result.has(composed)) {
-                result.set(composed, value);
-              }
-            }
-          }
-          reset();
-        }
-        continue;
-      }
-      if (abandonedObject) continue;
-
-      switch (state) {
-        case 'InObjectBody':
-          if (c === 'object.key') {
-            currentKey = token.token;
-            state = 'InObjectAfterKey';
-          }
-          break;
-        case 'InObjectAfterKey':
-          if (c === 'acessor.doublecolon') {
-            state = 'InObjectAfterColon';
-          } else {
-            state = 'InObjectBody';
-          }
-          break;
-        case 'InObjectAfterColon':
-          if (c === 'string') {
-            captureProps.push({ key: currentKey, value: token.token });
-          }
-          state = 'InObjectBody';
-          break;
-      }
-      continue;
-    }
-
-    // Top-level state machine.
-    switch (state) {
-      case 'Idle':
-        if (c === 'block.begin') {
-          funcDepth = 1;
-        } else if (!c && token.token === 'const') {
-          state = 'AfterConst';
-        }
-        // `export` and other prefixes simply stay in Idle until the
-        // following `const` token is seen.
-        break;
-
-      case 'AfterConst':
-        if (c === 'variable') {
-          captureName = token.token;
-          state = 'AfterName';
-        } else if (c === 'block.begin' || c === 'list.begin') {
-          // Destructure pattern like `const { x } = ...` — skip until
-          // the destructure pattern closes by piggybacking on funcDepth.
-          funcDepth = 1;
-          state = 'Idle';
-        } else {
-          state = 'Idle';
-        }
-        break;
-
-      case 'AfterName':
-        if (c === 'operator.assignment') {
-          state = 'AfterAssign';
-        } else if (c === 'acessor.doublecolon') {
-          state = 'InTypeAnnotation';
-        } else {
-          state = 'Idle';
-        }
-        break;
-
-      case 'InTypeAnnotation':
-        if (c === 'operator.assignment') {
-          state = 'AfterAssign';
-        } else if (c === 'block.begin') {
-          // Type-level block like `const X: { foo: 1 } = ...`. Bail out
-          // of this declaration; the rest is content we can't reason
-          // about with this state machine.
-          funcDepth = 1;
-          state = 'Idle';
-        }
-        // Otherwise just skip over the type tokens.
-        break;
-
-      case 'AfterAssign':
-        if (c === 'string') {
-          if (!result.has(captureName)) {
-            result.set(captureName, token.token);
-          }
-          reset();
-        } else if (c === 'block.begin') {
-          objectDepth = 1;
-          state = 'InObjectBody';
-        } else {
-          state = 'Idle';
-        }
-        break;
+    if (ctx.funcDepth > 0) {
+      stepInFunctionBody(ctx, token);
+    } else if (ctx.objectDepth > 0) {
+      stepInObjectBody(ctx, token);
+    } else {
+      stepAtTopLevel(ctx, token);
     }
   }
 
-  return result;
+  return ctx.result;
 }

--- a/src/extractor/parser/extractConstants.ts
+++ b/src/extractor/parser/extractConstants.ts
@@ -1,0 +1,30 @@
+/**
+ * Pre-pass over the source code that builds a map of top-level
+ * `const NAME = 'literal'` (optionally with `as const`) bindings.
+ *
+ * The extractor walks tokens, not the TS AST, so it cannot natively resolve
+ * an identifier passed to `useTranslate(NS)` or `<T ns={NS}>` back to its
+ * declaration. This helper produces a small symbol table the parser
+ * substitutes in when it sees a variable reference.
+ *
+ * Only declarations that initialise to a single string literal are recorded.
+ * Anything dynamic (concatenation, function call, template with interpolation,
+ * conditional expression, …) is intentionally skipped so the existing
+ * dynamic-namespace warning still fires for those cases.
+ */
+const CONST_LITERAL_RE =
+  /(?:^|[\n\r])[ \t]*(?:export[ \t]+)?const[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?::[^=]*)?=[ \t]*(['"`])((?:\\.|(?!\2)[^\\\n\r])*)\2(?:[ \t]+as[ \t]+const)?[ \t]*;?/g;
+
+export function extractConstants(code: string): Map<string, string> {
+  const result = new Map<string, string>();
+  let match: RegExpExecArray | null;
+  CONST_LITERAL_RE.lastIndex = 0;
+  while ((match = CONST_LITERAL_RE.exec(code))) {
+    const [, name, , value] = match;
+    // First declaration wins; duplicate declarations are a TS error anyway.
+    if (!result.has(name)) {
+      result.set(name, value);
+    }
+  }
+  return result;
+}

--- a/src/extractor/parser/extractConstants.ts
+++ b/src/extractor/parser/extractConstants.ts
@@ -1,30 +1,64 @@
 /**
- * Pre-pass over the source code that builds a map of top-level
- * `const NAME = 'literal'` (optionally with `as const`) bindings.
+ * Pre-pass over the source code that builds a flat map of top-level constant
+ * string bindings.
  *
- * The extractor walks tokens, not the TS AST, so it cannot natively resolve
- * an identifier passed to `useTranslate(NS)` or `<T ns={NS}>` back to its
- * declaration. This helper produces a small symbol table the parser
- * substitutes in when it sees a variable reference.
+ * Two declaration shapes are recognised:
  *
- * Only declarations that initialise to a single string literal are recorded.
- * Anything dynamic (concatenation, function call, template with interpolation,
- * conditional expression, …) is intentionally skipped so the existing
- * dynamic-namespace warning still fires for those cases.
+ *   const NAME = 'literal'
+ *   const NAME = 'literal' as const
+ *
+ * and (flat) string-valued object literals:
+ *
+ *   const NS = { KEY1: 'literal1', KEY2: 'literal2' } as const
+ *   const NS = { KEY1: 'literal1', KEY2: 'literal2' }
+ *
+ * Object literals are flattened, so the second example produces entries
+ * `NS.KEY1 → 'literal1'` and `NS.KEY2 → 'literal2'`. Nested objects are
+ * intentionally skipped (the existing dynamic-namespace warning still
+ * fires for those).
+ *
+ * The extractor walks tokens, not the TS AST, so it cannot natively
+ * resolve an identifier passed to `useTranslate(NS)` or `<T ns={NS.X}>`
+ * back to its declaration. This helper produces a small symbol table
+ * the parser substitutes in when it sees a variable reference.
  */
 const CONST_LITERAL_RE =
   /(?:^|[\n\r])[ \t]*(?:export[ \t]+)?const[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?::[^=]*)?=[ \t]*(['"`])((?:\\.|(?!\2)[^\\\n\r])*)\2(?:[ \t]+as[ \t]+const)?[ \t]*;?/g;
 
+// Only matches object literals without nested braces. That's enough for the
+// `const NS = { ... } as const` pattern and keeps the regex tractable.
+const CONST_OBJECT_RE =
+  /(?:^|[\n\r])[ \t]*(?:export[ \t]+)?const[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?::[^=]*)?=[ \t]*\{([^{}]*)\}(?:[ \t]+as[ \t]+const)?[ \t]*;?/g;
+
+const OBJECT_PROPERTY_RE =
+  /(?:^|[,{\s])([A-Za-z_$][\w$]*)[ \t]*:[ \t]*(['"`])((?:\\.|(?!\2)[^\\\n\r])*)\2/g;
+
 export function extractConstants(code: string): Map<string, string> {
   const result = new Map<string, string>();
+
   let match: RegExpExecArray | null;
+
   CONST_LITERAL_RE.lastIndex = 0;
   while ((match = CONST_LITERAL_RE.exec(code))) {
     const [, name, , value] = match;
-    // First declaration wins; duplicate declarations are a TS error anyway.
     if (!result.has(name)) {
       result.set(name, value);
     }
   }
+
+  CONST_OBJECT_RE.lastIndex = 0;
+  while ((match = CONST_OBJECT_RE.exec(code))) {
+    const [, objectName, body] = match;
+    OBJECT_PROPERTY_RE.lastIndex = 0;
+    let propMatch: RegExpExecArray | null;
+    while ((propMatch = OBJECT_PROPERTY_RE.exec(body))) {
+      const [, propName, , propValue] = propMatch;
+      const key = `${objectName}.${propName}`;
+      if (!result.has(key)) {
+        result.set(key, propValue);
+      }
+    }
+  }
+
   return result;
 }

--- a/src/extractor/parser/extractConstants.ts
+++ b/src/extractor/parser/extractConstants.ts
@@ -87,11 +87,10 @@ function resetCapture(ctx: Context): void {
 
 function finalizeObjectCapture(ctx: Context): void {
   if (!ctx.abandonedObject) {
+    // Mirror JS object-literal semantics: a later property with the same
+    // name overwrites earlier ones, so always assign.
     for (const { key, value } of ctx.captureProps) {
-      const composed = `${ctx.captureName}.${key}`;
-      if (!ctx.result.has(composed)) {
-        ctx.result.set(composed, value);
-      }
+      ctx.result.set(`${ctx.captureName}.${key}`, value);
     }
   }
   resetCapture(ctx);

--- a/src/extractor/parser/extractConstants.ts
+++ b/src/extractor/parser/extractConstants.ts
@@ -52,6 +52,11 @@ type Context = {
   // > 0, top-level const-detection is suspended; only block.begin/end
   // are tracked so we know when we resurface.
   funcDepth: number;
+  // Depth of a square-bracket pattern (array literal or array
+  // destructure) we're currently skipping. Tracked separately from
+  // funcDepth so list.begin/end never leaks into block depth and vice
+  // versa.
+  listDepth: number;
   // Depth of the object literal currently being captured (1 = top of
   // the object body). Tracked separately from funcDepth so a nested
   // object literal value abandons capture without leaking depth.
@@ -69,6 +74,7 @@ function createContext(): Context {
     result: new Map(),
     state: 'Idle',
     funcDepth: 0,
+    listDepth: 0,
     objectDepth: 0,
     captureName: '',
     captureProps: [],
@@ -100,6 +106,12 @@ function finalizeObjectCapture(ctx: Context): void {
 function stepInFunctionBody(ctx: Context, token: AnyToken): void {
   if (token.customType === 'block.begin') ctx.funcDepth++;
   else if (token.customType === 'block.end') ctx.funcDepth--;
+}
+
+/** Skip an array literal / array destructure pattern at top level. */
+function stepInListSkip(ctx: Context, token: AnyToken): void {
+  if (token.customType === 'list.begin') ctx.listDepth++;
+  else if (token.customType === 'list.end') ctx.listDepth--;
 }
 
 /** Walk the body of a `const NS = { ... }` capture. */
@@ -162,10 +174,18 @@ function stepAtTopLevel(ctx: Context, token: AnyToken): void {
       if (c === 'variable') {
         ctx.captureName = token.token;
         ctx.state = 'AfterName';
-      } else if (c === 'block.begin' || c === 'list.begin') {
-        // Destructure pattern like `const { x } = ...` — skip until
-        // the destructure pattern closes by piggybacking on funcDepth.
+      } else if (c === 'block.begin') {
+        // Object destructure pattern like `const { x } = ...` — skip
+        // until the matching block.end via funcDepth.
         ctx.funcDepth = 1;
+        ctx.state = 'Idle';
+      } else if (c === 'list.begin') {
+        // Array destructure pattern like `const [x] = ...` — skip
+        // until the matching list.end via listDepth. Tracked
+        // separately from funcDepth because stepInFunctionBody only
+        // consumes block.begin/end and would never see the closing
+        // bracket, leaving funcDepth permanently > 0.
+        ctx.listDepth = 1;
         ctx.state = 'Idle';
       } else {
         ctx.state = 'Idle';
@@ -219,6 +239,8 @@ export function extractConstants(
   for (const token of tokens) {
     if (ctx.funcDepth > 0) {
       stepInFunctionBody(ctx, token);
+    } else if (ctx.listDepth > 0) {
+      stepInListSkip(ctx, token);
     } else if (ctx.objectDepth > 0) {
       stepInObjectBody(ctx, token);
     } else {

--- a/src/extractor/parser/extractConstants.ts
+++ b/src/extractor/parser/extractConstants.ts
@@ -1,6 +1,8 @@
+import { Token } from './types.js';
+
 /**
- * Pre-pass over the source code that builds a flat map of top-level constant
- * string bindings.
+ * Pre-pass over the merged token stream that builds a flat map of
+ * module-top-level constant string bindings.
  *
  * Two declaration shapes are recognised:
  *
@@ -13,50 +15,181 @@
  *   const NS = { KEY1: 'literal1', KEY2: 'literal2' }
  *
  * Object literals are flattened, so the second example produces entries
- * `NS.KEY1 → 'literal1'` and `NS.KEY2 → 'literal2'`. Nested objects are
- * intentionally skipped (the existing dynamic-namespace warning still
- * fires for those).
+ * `NS.KEY1 -> 'literal1'` and `NS.KEY2 -> 'literal2'`. Nested objects
+ * are intentionally skipped (the existing dynamic-namespace warning
+ * still fires for those).
  *
  * The extractor walks tokens, not the TS AST, so it cannot natively
  * resolve an identifier passed to `useTranslate(NS)` or `<T ns={NS.X}>`
- * back to its declaration. This helper produces a small symbol table
+ * back to its declaration. This helper produces the small symbol table
  * the parser substitutes in when it sees a variable reference.
+ *
+ * Walking the already-merged token stream (rather than running regex on
+ * the raw source) means strings, comments, template literals and block
+ * delimiters are already correctly classified by TextMate. In particular
+ * the `funcDepth` counter below ensures we only capture declarations at
+ * module top level — a `const X = '...'` nested inside a function body
+ * or branch is invisible to the capture, which matches the visibility
+ * the consumer of the identifier would have.
  */
-const CONST_LITERAL_RE =
-  /(?:^|[\n\r])[ \t]*(?:export[ \t]+)?const[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?::[^=]*)?=[ \t]*(['"`])((?:\\.|(?!\2)[^\\\n\r])*)\2(?:[ \t]+as[ \t]+const)?[ \t]*;?/g;
-
-// Only matches object literals without nested braces. That's enough for the
-// `const NS = { ... } as const` pattern and keeps the regex tractable.
-const CONST_OBJECT_RE =
-  /(?:^|[\n\r])[ \t]*(?:export[ \t]+)?const[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?::[^=]*)?=[ \t]*\{([^{}]*)\}(?:[ \t]+as[ \t]+const)?[ \t]*;?/g;
-
-const OBJECT_PROPERTY_RE =
-  /(?:^|[,{\s])([A-Za-z_$][\w$]*)[ \t]*:[ \t]*(['"`])((?:\\.|(?!\2)[^\\\n\r])*)\2/g;
-
-export function extractConstants(code: string): Map<string, string> {
+export function extractConstants(
+  tokens: ReadonlyArray<Token<string | undefined>>
+): Map<string, string> {
   const result = new Map<string, string>();
 
-  let match: RegExpExecArray | null;
+  type State =
+    | 'Idle'
+    | 'AfterConst'
+    | 'AfterName'
+    | 'InTypeAnnotation'
+    | 'AfterAssign'
+    | 'InObjectBody'
+    | 'InObjectAfterKey'
+    | 'InObjectAfterColon';
 
-  CONST_LITERAL_RE.lastIndex = 0;
-  while ((match = CONST_LITERAL_RE.exec(code))) {
-    const [, name, , value] = match;
-    if (!result.has(name)) {
-      result.set(name, value);
+  let state: State = 'Idle';
+  // Depth of block/control-flow bodies we're currently inside. While
+  // > 0, top-level const-detection is suspended; only block.begin/end
+  // are tracked so we know when we resurface.
+  let funcDepth = 0;
+  // Depth of the object literal currently being captured (1 = top of
+  // the object body). Tracked separately from funcDepth so a nested
+  // object literal value abandons capture without leaking depth.
+  let objectDepth = 0;
+  let captureName = '';
+  let captureProps: Array<{ key: string; value: string }> = [];
+  let currentKey = '';
+  let abandonedObject = false;
+
+  const reset = () => {
+    state = 'Idle';
+    captureProps = [];
+    captureName = '';
+    currentKey = '';
+    abandonedObject = false;
+  };
+
+  for (const token of tokens) {
+    const c = token.customType;
+
+    // Inside a function body / control-flow block — nothing here is at
+    // module top level so skip until we resurface.
+    if (funcDepth > 0) {
+      if (c === 'block.begin') funcDepth++;
+      else if (c === 'block.end') funcDepth--;
+      continue;
     }
-  }
 
-  CONST_OBJECT_RE.lastIndex = 0;
-  while ((match = CONST_OBJECT_RE.exec(code))) {
-    const [, objectName, body] = match;
-    OBJECT_PROPERTY_RE.lastIndex = 0;
-    let propMatch: RegExpExecArray | null;
-    while ((propMatch = OBJECT_PROPERTY_RE.exec(body))) {
-      const [, propName, , propValue] = propMatch;
-      const key = `${objectName}.${propName}`;
-      if (!result.has(key)) {
-        result.set(key, propValue);
+    // Object literal capture — has its own depth counter.
+    if (objectDepth > 0) {
+      if (c === 'block.begin') {
+        objectDepth++;
+        abandonedObject = true;
+        continue;
       }
+      if (c === 'block.end') {
+        objectDepth--;
+        if (objectDepth === 0) {
+          if (!abandonedObject) {
+            for (const { key, value } of captureProps) {
+              const composed = `${captureName}.${key}`;
+              if (!result.has(composed)) {
+                result.set(composed, value);
+              }
+            }
+          }
+          reset();
+        }
+        continue;
+      }
+      if (abandonedObject) continue;
+
+      switch (state) {
+        case 'InObjectBody':
+          if (c === 'object.key') {
+            currentKey = token.token;
+            state = 'InObjectAfterKey';
+          }
+          break;
+        case 'InObjectAfterKey':
+          if (c === 'acessor.doublecolon') {
+            state = 'InObjectAfterColon';
+          } else {
+            state = 'InObjectBody';
+          }
+          break;
+        case 'InObjectAfterColon':
+          if (c === 'string') {
+            captureProps.push({ key: currentKey, value: token.token });
+          }
+          state = 'InObjectBody';
+          break;
+      }
+      continue;
+    }
+
+    // Top-level state machine.
+    switch (state) {
+      case 'Idle':
+        if (c === 'block.begin') {
+          funcDepth = 1;
+        } else if (!c && token.token === 'const') {
+          state = 'AfterConst';
+        }
+        // `export` and other prefixes simply stay in Idle until the
+        // following `const` token is seen.
+        break;
+
+      case 'AfterConst':
+        if (c === 'variable') {
+          captureName = token.token;
+          state = 'AfterName';
+        } else if (c === 'block.begin' || c === 'list.begin') {
+          // Destructure pattern like `const { x } = ...` — skip until
+          // the destructure pattern closes by piggybacking on funcDepth.
+          funcDepth = 1;
+          state = 'Idle';
+        } else {
+          state = 'Idle';
+        }
+        break;
+
+      case 'AfterName':
+        if (c === 'operator.assignment') {
+          state = 'AfterAssign';
+        } else if (c === 'acessor.doublecolon') {
+          state = 'InTypeAnnotation';
+        } else {
+          state = 'Idle';
+        }
+        break;
+
+      case 'InTypeAnnotation':
+        if (c === 'operator.assignment') {
+          state = 'AfterAssign';
+        } else if (c === 'block.begin') {
+          // Type-level block like `const X: { foo: 1 } = ...`. Bail out
+          // of this declaration; the rest is content we can't reason
+          // about with this state machine.
+          funcDepth = 1;
+          state = 'Idle';
+        }
+        // Otherwise just skip over the type tokens.
+        break;
+
+      case 'AfterAssign':
+        if (c === 'string') {
+          if (!result.has(captureName)) {
+            result.set(captureName, token.token);
+          }
+          reset();
+        } else if (c === 'block.begin') {
+          objectDepth = 1;
+          state = 'InObjectBody';
+        } else {
+          state = 'Idle';
+        }
+        break;
     }
   }
 

--- a/src/extractor/parser/generalMapper.ts
+++ b/src/extractor/parser/generalMapper.ts
@@ -37,6 +37,9 @@ export const generalMapper = (token: Token) => {
     // variables
     case 'variable.other.object.ts':
     case 'variable.other.constant.ts':
+    case 'variable.other.constant.object.ts':
+    case 'variable.other.constant.property.ts':
+    case 'variable.other.property.ts':
     case 'variable.language.this.ts':
       return 'variable';
 

--- a/src/extractor/parser/parser.ts
+++ b/src/extractor/parser/parser.ts
@@ -24,6 +24,7 @@ import { closingTagMerger } from './tokenMergers/closingTagMerger.js';
 import { typesAsMerger } from './tokenMergers/typesAsMerger.js';
 import { typesCastMerger } from './tokenMergers/typesCastMerger.js';
 import { customTCallMerger } from './tokenMergers/customTCallMerger.js';
+import { extractConstants } from './extractConstants.js';
 
 export const DEFAULT_BLOCKS = {
   'block.begin': ['block.end'],
@@ -57,6 +58,7 @@ type ParseOptions<T extends string = GeneralTokenType> = {
   tokens: Iterable<Token<any>>;
   onAccept?: IteratorListener<T>;
   options: ExtractOptions;
+  code?: string;
 };
 
 export const Parser = <T extends string = GeneralTokenType>({
@@ -78,7 +80,7 @@ export const Parser = <T extends string = GeneralTokenType>({
   }
 
   return {
-    parse({ tokens, onAccept, options }: ParseOptions<T>) {
+    parse({ tokens, onAccept, options, code }: ParseOptions<T>) {
       for (const t of tokens) {
         // use first mapper, which gives some result
         const type = mappers.find((mapper) => mapper(t))?.(t);
@@ -124,6 +126,7 @@ export const Parser = <T extends string = GeneralTokenType>({
         withLabel,
         ruleMap,
         blocks,
+        constants: code ? extractConstants(code) : new Map(),
       };
 
       let depth = 0;

--- a/src/extractor/parser/parser.ts
+++ b/src/extractor/parser/parser.ts
@@ -58,7 +58,6 @@ type ParseOptions<T extends string = GeneralTokenType> = {
   tokens: Iterable<Token<any>>;
   onAccept?: IteratorListener<T>;
   options: ExtractOptions;
-  code?: string;
 };
 
 export const Parser = <T extends string = GeneralTokenType>({
@@ -80,7 +79,7 @@ export const Parser = <T extends string = GeneralTokenType>({
   }
 
   return {
-    parse({ tokens, onAccept, options, code }: ParseOptions<T>) {
+    parse({ tokens, onAccept, options }: ParseOptions<T>) {
       for (const t of tokens) {
         // use first mapper, which gives some result
         const type = mappers.find((mapper) => mapper(t))?.(t);
@@ -126,7 +125,7 @@ export const Parser = <T extends string = GeneralTokenType>({
         withLabel,
         ruleMap,
         blocks,
-        constants: code ? extractConstants(code) : new Map(),
+        constants: extractConstants(filteredIgnored),
       };
 
       let depth = 0;

--- a/src/extractor/parser/tree/getValue.ts
+++ b/src/extractor/parser/tree/getValue.ts
@@ -19,6 +19,25 @@ export function getValue<T extends string = GeneralTokenType>(
       });
 
     case 'variable': {
+      // Look ahead for a same-file `NAME.PROP` member access. The tokens
+      // are forward-only, but the only way `variable + acessor.dot +
+      // variable` shows up in a value position is when the user is
+      // referencing a constants object — consuming those tokens here
+      // doesn't disrupt any other parse path.
+      const next = context.tokens.peek();
+      if (next?.customType === 'acessor.dot') {
+        context.tokens.next();
+        const afterDot = context.tokens.peek();
+        if (afterDot?.customType === 'variable') {
+          context.tokens.next();
+          const memberKey = `${token.token}.${afterDot.token}`;
+          const memberResolved = context.constants.get(memberKey);
+          if (memberResolved !== undefined) {
+            return { type: 'primitive', line, value: memberResolved };
+          }
+          return { type: 'expr', line, values: [] };
+        }
+      }
       const resolved = context.constants.get(token.token);
       if (resolved !== undefined) {
         return { type: 'primitive', line, value: resolved };

--- a/src/extractor/parser/tree/getValue.ts
+++ b/src/extractor/parser/tree/getValue.ts
@@ -18,6 +18,14 @@ export function getValue<T extends string = GeneralTokenType>(
         end: ['expression.end'] as T[],
       });
 
+    case 'variable': {
+      const resolved = context.constants.get(token.token);
+      if (resolved !== undefined) {
+        return { type: 'primitive', line, value: resolved };
+      }
+      return { type: 'expr', line, values: [] };
+    }
+
     default:
       return { type: 'expr', line, values: [] };
   }

--- a/src/extractor/parser/types.ts
+++ b/src/extractor/parser/types.ts
@@ -89,6 +89,7 @@ export type ParserContext<T extends string = GeneralTokenType> = {
   withLabel: <S extends any[], U>(fn: (...args: S) => U) => (...args: S) => U;
   ruleMap: RuleMap<T>;
   blocks: BlocksType;
+  constants: Map<string, string>;
 };
 
 export type ExtractorInternal = (

--- a/test/unit/extractor/react/tComponent.test.ts
+++ b/test/unit/extractor/react/tComponent.test.ts
@@ -363,4 +363,38 @@ describe.each(['jsx', 'tsx'])('<T> (.%s)', (ext) => {
       expect(extracted.keys).toEqual(expectedKeys);
     });
   });
+
+  describe('top-level const namespace identifiers', () => {
+    it('resolves a const used as the `ns` prop of <T>', async () => {
+      const code = `
+        import { T } from '@tolgee/react'
+        const NS = 'auth'
+        function Test () {
+          return <T keyName="key1" ns={NS} />
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([]);
+      expect(extracted.keys).toEqual([
+        { keyName: 'key1', namespace: 'auth', line: 5 },
+      ]);
+    });
+
+    it('resolves an `as const` declaration used as `ns` prop', async () => {
+      const code = `
+        import { T } from '@tolgee/react'
+        export const NS = 'billing' as const
+        function Test () {
+          return <T keyName="key1" ns={NS} />
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([]);
+      expect(extracted.keys).toEqual([
+        { keyName: 'key1', namespace: 'billing', line: 5 },
+      ]);
+    });
+  });
 });

--- a/test/unit/extractor/react/tComponent.test.ts
+++ b/test/unit/extractor/react/tComponent.test.ts
@@ -396,5 +396,21 @@ describe.each(['jsx', 'tsx'])('<T> (.%s)', (ext) => {
         { keyName: 'key1', namespace: 'billing', line: 5 },
       ]);
     });
+
+    it('resolves member access on a const object used as `ns` prop', async () => {
+      const code = `
+        import { T } from '@tolgee/react'
+        const NS = { AUTH: 'auth', NAMESPACED: 'namespaced' } as const
+        function Test () {
+          return <T keyName="key1" ns={NS.NAMESPACED} />
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([]);
+      expect(extracted.keys).toEqual([
+        { keyName: 'key1', namespace: 'namespaced', line: 5 },
+      ]);
+    });
   });
 });

--- a/test/unit/extractor/react/useTranslate.test.ts
+++ b/test/unit/extractor/react/useTranslate.test.ts
@@ -619,6 +619,23 @@ describe.each(['js', 'ts', 'jsx', 'tsx'])('useTranslate (.%s)', (ext) => {
       ]);
     });
 
+    it('matches JS last-write-wins for duplicate object keys', async () => {
+      const code = `
+        import '@tolgee/react'
+        const NS = { K: 'first', K: 'second' } as const
+        function Test () {
+          const { t } = useTranslate(NS.K)
+          t('key1')
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([]);
+      expect(extracted.keys).toEqual([
+        { keyName: 'key1', namespace: 'second', line: 6 },
+      ]);
+    });
+
     it('ignores const declarations nested inside function bodies', async () => {
       // A function-local `const NS` must not shadow what the consumer
       // would see at module scope. Here there is no module-level NS,

--- a/test/unit/extractor/react/useTranslate.test.ts
+++ b/test/unit/extractor/react/useTranslate.test.ts
@@ -585,6 +585,58 @@ describe.each(['js', 'ts', 'jsx', 'tsx'])('useTranslate (.%s)', (ext) => {
       ]);
     });
 
+    it('resolves member access on a const object (`as const`)', async () => {
+      const code = `
+        import '@tolgee/react'
+        const NS = { AUTH: 'auth', BILLING: 'billing' } as const
+        function Test () {
+          const { t } = useTranslate(NS.BILLING)
+          t('key1')
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([]);
+      expect(extracted.keys).toEqual([
+        { keyName: 'key1', namespace: 'billing', line: 6 },
+      ]);
+    });
+
+    it('resolves member access on a plain const object (no `as const`)', async () => {
+      const code = `
+        import '@tolgee/react'
+        const NS = { AUTH: 'auth' }
+        function Test () {
+          const { t } = useTranslate(NS.AUTH)
+          t('key1')
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([]);
+      expect(extracted.keys).toEqual([
+        { keyName: 'key1', namespace: 'auth', line: 6 },
+      ]);
+    });
+
+    it('still warns for member access on an unknown property', async () => {
+      const code = `
+        import '@tolgee/react'
+        const NS = { AUTH: 'auth' } as const
+        function Test () {
+          const { t } = useTranslate(NS.BILLING)
+          t('key1')
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([
+        { warning: 'W_DYNAMIC_NAMESPACE', line: 5 },
+        { warning: 'W_UNRESOLVABLE_NAMESPACE', line: 6 },
+      ]);
+      expect(extracted.keys).toEqual([]);
+    });
+
     it('still emits a warning for identifiers without a const declaration', async () => {
       const code = `
         import '@tolgee/react'

--- a/test/unit/extractor/react/useTranslate.test.ts
+++ b/test/unit/extractor/react/useTranslate.test.ts
@@ -636,6 +636,27 @@ describe.each(['js', 'ts', 'jsx', 'tsx'])('useTranslate (.%s)', (ext) => {
       ]);
     });
 
+    it('keeps capturing after a top-level array destructure', async () => {
+      // Regression: `const [a, b] = ...` is a list-destructure pattern.
+      // It must not leave the walker stuck in skip mode, otherwise the
+      // subsequent `const NS = ...` would silently fail to be captured.
+      const code = `
+        import '@tolgee/react'
+        const [first, second] = ['x', 'y']
+        const NS = 'after-destructure'
+        function Test () {
+          const { t } = useTranslate(NS)
+          t('key1')
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([]);
+      expect(extracted.keys).toEqual([
+        { keyName: 'key1', namespace: 'after-destructure', line: 7 },
+      ]);
+    });
+
     it('ignores const declarations nested inside function bodies', async () => {
       // A function-local `const NS` must not shadow what the consumer
       // would see at module scope. Here there is no module-level NS,

--- a/test/unit/extractor/react/useTranslate.test.ts
+++ b/test/unit/extractor/react/useTranslate.test.ts
@@ -549,4 +549,57 @@ describe.each(['js', 'ts', 'jsx', 'tsx'])('useTranslate (.%s)', (ext) => {
       expect(extracted.warnings).toEqual([]);
     });
   });
+
+  describe('top-level const namespace identifiers', () => {
+    it('resolves a plain const string to its literal value', async () => {
+      const code = `
+        import '@tolgee/react'
+        const NS = 'my-namespace'
+        function Test () {
+          const { t } = useTranslate(NS)
+          t('key1')
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([]);
+      expect(extracted.keys).toEqual([
+        { keyName: 'key1', namespace: 'my-namespace', line: 6 },
+      ]);
+    });
+
+    it('resolves an exported `as const` declaration', async () => {
+      const code = `
+        import '@tolgee/react'
+        export const NS = 'billing' as const
+        function Test () {
+          const { t } = useTranslate(NS)
+          t('key1')
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([]);
+      expect(extracted.keys).toEqual([
+        { keyName: 'key1', namespace: 'billing', line: 6 },
+      ]);
+    });
+
+    it('still emits a warning for identifiers without a const declaration', async () => {
+      const code = `
+        import '@tolgee/react'
+        function Test () {
+          const { t } = useTranslate(unknownNs)
+          t('key1')
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([
+        { warning: 'W_DYNAMIC_NAMESPACE', line: 4 },
+        { warning: 'W_UNRESOLVABLE_NAMESPACE', line: 5 },
+      ]);
+      expect(extracted.keys).toEqual([]);
+    });
+  });
 });

--- a/test/unit/extractor/react/useTranslate.test.ts
+++ b/test/unit/extractor/react/useTranslate.test.ts
@@ -619,6 +619,31 @@ describe.each(['js', 'ts', 'jsx', 'tsx'])('useTranslate (.%s)', (ext) => {
       ]);
     });
 
+    it('ignores const declarations nested inside function bodies', async () => {
+      // A function-local `const NS` must not shadow what the consumer
+      // would see at module scope. Here there is no module-level NS,
+      // so the call site should produce the existing dynamic-namespace
+      // warning, not be silently resolved to the inner literal.
+      const code = `
+        import '@tolgee/react'
+        function helper () {
+          const NS = 'inner-only'
+          return NS
+        }
+        function Test () {
+          const { t } = useTranslate(NS)
+          t('key1')
+        }
+      `;
+
+      const extracted = await extractReactKeys(code, FILE_NAME);
+      expect(extracted.warnings).toEqual([
+        { warning: 'W_DYNAMIC_NAMESPACE', line: 8 },
+        { warning: 'W_UNRESOLVABLE_NAMESPACE', line: 9 },
+      ]);
+      expect(extracted.keys).toEqual([]);
+    });
+
     it('still warns for member access on an unknown property', async () => {
       const code = `
         import '@tolgee/react'


### PR DESCRIPTION
## Problem

The extractor warns `W_DYNAMIC_NAMESPACE` whenever a namespace is
referenced through a constant instead of a literal:

```ts
const namespaceName = 'myNamespace';
const { t } = useTranslate(namespaceName); // ← W_DYNAMIC_NAMESPACE

const NS = { AUTH: 'auth' } as const;
const { t } = useTranslate(NS.AUTH);       // ← W_DYNAMIC_NAMESPACE
```

This is exactly the shape customers reach for to avoid namespace typos
(a typed constants object on top of which TypeScript catches typos).
Today, choosing safety means losing extraction. The only workarounds
are bare literals everywhere or `@tolgee-key` magic comments at every
call site.

## Solution

A small per-file constant pre-pass runs before parsing and builds a
flat `Map<string, string>`. It walks the already-merged token stream
(not regex over raw source, and not the TS AST), using a small state
machine with a `funcDepth` counter so only module-top-level
declarations are captured:

- `const NAME = 'literal' (as const)?` → `NAME → 'literal'`
- `const NS = { K1: 'l1', K2: 'l2' } as const` → `NS.K1 → 'l1'`, `NS.K2 → 'l2'`
- Object-literal form supports the non-`as const` variant too. Nested
  objects are intentionally skipped (existing dynamic warning still
  fires).
- Duplicate keys within an object literal resolve last-write-wins,
  matching JS object semantics.

The map is threaded through `ParserContext.constants`. `getValue.ts`
resolves bare `variable` tokens via the map, and a one-step lookahead
catches the `variable + dot + variable` (member-access) pattern.

A few additional TextMate scopes (`variable.other.constant.object.ts`,
`variable.other.constant.property.ts`, `variable.other.property.ts`)
are mapped to the `variable` customType — without that, tokens inside
`useTranslate(NS.K)` arrive with `customType: undefined` and bypass
parsing entirely.

## Scope and limitations

- **Same-file only.** Cross-file `import { NS } from './namespaces'`
  is still warned. Following imports is a fair chunk more work (module
  resolution, alias paths, ts-morph or equivalent) and explicitly out
  of scope for this PR.
- Member access is limited to one level (`NS.KEY`). Deeper paths still
  warn.
- Only module-top-level `const` declarations are captured; a
  `const X = '...'` nested inside a function body or branch is invisible
  to the pre-pass, matching the visibility the call site would have.
- Nested object literals are skipped (only flat string-valued objects
  are flattened into the map).

## Verification

- `npm run test:unit` — 646 passed.
- Specifically:
  - `test/unit/extractor/react/useTranslate.test.ts` — 140 tests.
  - `test/unit/extractor/react/tComponent.test.ts` — 42 tests.
- Vue / Svelte / Ngx parser suites all remain green (shared parser
  files were modified).
- End-to-end on the companion tolgee-js testapp `Namespaces.tsx`:
  3 keys extracted, namespace `namespaced`, zero warnings.

## Test plan

- [ ] Customer pattern reproduces and warning is gone for the same-file
      shape.
- [ ] No regression for the existing dynamic-key/dynamic-default-value
      paths.
- [ ] Cross-file case is documented as a known limitation (PR
      description and the new `extractConstants.ts` doc comment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extractor now resolves module-level constant declarations when analyzing component props and function arguments, supporting plain constants, const-asserted declarations, and nested object properties for improved namespace and key extraction.

* **Tests**
  * Added comprehensive test coverage for constant resolution scenarios, including various declaration patterns, duplicate key handling, and negative cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
