### PR TITLE
feat: support extra HTTP headers on API requests

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
   API_URL_OPT,
   CONFIG_OPT,
   DEFAULT_NAMESPACE,
+  EXTRA_HEADERS,
   EXTRACTOR,
   FILE_PATTERNS,
   FORMAT_OPT,
@@ -150,6 +151,7 @@ const preHandler = (config: Schema) =>
             : config.projectId !== undefined
               ? Number(config.projectId)
               : undefined,
+        extraHeaders: opts.extraHeaders,
       });
 
       cmd.setOptionValue('client', client);
@@ -182,6 +184,7 @@ async function run() {
     program.addOption(CONFIG_OPT);
     program.addOption(API_URL_OPT.default(config.apiUrl ?? DEFAULT_API_URL));
     program.addOption(API_KEY_OPT.default(config.apiKey));
+    program.addOption(EXTRA_HEADERS);
     program.addOption(PROJECT_ID_OPT.default(config.projectId ?? -1));
     program.addOption(PROJECT_BRANCH.default(config.branch));
     program.addOption(FORMAT_OPT.default(config.format ?? 'JSON_TOLGEE'));

--- a/src/client/ApiClient.ts
+++ b/src/client/ApiClient.ts
@@ -55,6 +55,7 @@ export type ApiClientProps = {
   apiKey?: string;
   projectId?: number | undefined;
   autoThrow?: boolean;
+  extraHeaders?: Record<string, string>;
 };
 
 export function createApiClient({
@@ -62,6 +63,7 @@ export function createApiClient({
   apiKey,
   projectId,
   autoThrow = false,
+  extraHeaders,
 }: ApiClientProps) {
   const computedProjectId =
     projectId ?? (apiKey ? projectIdFromKey(apiKey) : undefined);
@@ -70,6 +72,7 @@ export function createApiClient({
     headers: {
       'user-agent': USER_AGENT,
       'x-api-key': apiKey,
+      ...extraHeaders,
     },
   });
 
@@ -110,7 +113,7 @@ export function createApiClient({
       return getApiKeyInformation(apiClient, apiKey!);
     },
     getSettings(): ApiClientProps {
-      return { baseUrl, apiKey, projectId, autoThrow };
+      return { baseUrl, apiKey, projectId, autoThrow, extraHeaders };
     },
   };
 }

--- a/src/client/ApiClient.ts
+++ b/src/client/ApiClient.ts
@@ -70,9 +70,9 @@ export function createApiClient({
   const apiClient = createClient<paths>({
     baseUrl,
     headers: {
+      ...extraHeaders,
       'user-agent': USER_AGENT,
       'x-api-key': apiKey,
-      ...extraHeaders,
     },
   });
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path';
 import { Option, InvalidArgumentError } from 'commander';
 import { createTolgeeClient } from './client/TolgeeClient.js';
 import { VerboseOption } from './extractor/index.js';
+import { parseExtraHeadersArg } from './utils/extraHeaders.js';
 
 function parseProjectId(v: string) {
   const val = Number(v);
@@ -39,6 +40,7 @@ export type BaseOptions = {
   patterns: string[] | undefined;
   strictNamespace: boolean | undefined;
   verbose: VerboseOption[] | boolean | undefined;
+  extraHeaders?: Record<string, string>;
 };
 
 export const API_KEY_OPT = new Option(
@@ -141,3 +143,10 @@ export const VERBOSE = new Option(
   '-v, --verbose [rules...]',
   'Enable verbose logging. If you want more info to be logged pass an option.'
 ).choices(['extractor']);
+
+export const EXTRA_HEADERS = new Option(
+  '--extra-headers <headers>',
+  "Additional HTTP headers to send with every Tolgee API request. Accepts comma-separated Name=Value pairs (e.g. 'X-Foo=bar,X-Baz=qux'). Useful for traversing Cloudflare Access, WAFs, or other gateways."
+)
+  .env('TOLGEE_EXTRA_HEADERS')
+  .argParser(parseExtraHeadersArg);

--- a/src/utils/extraHeaders.ts
+++ b/src/utils/extraHeaders.ts
@@ -1,0 +1,20 @@
+import { InvalidArgumentError } from 'commander';
+
+export function parseExtraHeadersArg(value: string): Record<string, string> {
+  const trimmed = value.trim();
+  if (!trimmed) return {};
+
+  const out: Record<string, string> = {};
+  for (const pair of trimmed.split(',')) {
+    const segment = pair.trim();
+    if (!segment) continue;
+    const idx = segment.indexOf('=');
+    if (idx <= 0) {
+      throw new InvalidArgumentError(
+        `Invalid extra header "${segment}". Use Name=Value.`
+      );
+    }
+    out[segment.slice(0, idx).trim()] = segment.slice(idx + 1).trim();
+  }
+  return out;
+}

--- a/test/unit/extraHeaders.test.ts
+++ b/test/unit/extraHeaders.test.ts
@@ -1,0 +1,39 @@
+import { parseExtraHeadersArg } from '#cli/utils/extraHeaders.js';
+
+describe('parseExtraHeadersArg', () => {
+  it('parses comma-separated Name=Value pairs', () => {
+    expect(parseExtraHeadersArg('X-Foo=bar, X-Baz=qux')).toEqual({
+      'X-Foo': 'bar',
+      'X-Baz': 'qux',
+    });
+  });
+
+  it('trims whitespace around names and values', () => {
+    expect(parseExtraHeadersArg('  X-Foo = bar  ')).toEqual({
+      'X-Foo': 'bar',
+    });
+  });
+
+  it('keeps "=" characters inside the value', () => {
+    expect(parseExtraHeadersArg('X-Token=abc=def=ghi')).toEqual({
+      'X-Token': 'abc=def=ghi',
+    });
+  });
+
+  it('skips empty segments', () => {
+    expect(parseExtraHeadersArg('X-Foo=bar,,X-Baz=qux,')).toEqual({
+      'X-Foo': 'bar',
+      'X-Baz': 'qux',
+    });
+  });
+
+  it('returns empty for empty input', () => {
+    expect(parseExtraHeadersArg('')).toEqual({});
+    expect(parseExtraHeadersArg('   ')).toEqual({});
+  });
+
+  it('rejects malformed pairs', () => {
+    expect(() => parseExtraHeadersArg('not-a-header')).toThrow();
+    expect(() => parseExtraHeadersArg('=missing-name')).toThrow();
+  });
+});


### PR DESCRIPTION
Adds a `--extra-headers` option (and `TOLGEE_EXTRA_HEADERS` env var) to send extra HTTP headers with every Tolgee API request.

Useful for self-hosted instances behind a gateway (Cloudflare Access, WAF, reverse proxy) that requires auth headers.

Headers are comma-separated `Name=Value` pairs:
    `tolgee --extra-headers 'X-Foo=bar,X-Baz=qux' pull`

Added unit tests for the parser. eslint, type check, and unit tests pass.

 Closes #180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI accepts a --extra-headers option (or TOLGEE_EXTRA_HEADERS) with comma-separated Name=Value pairs to inject custom HTTP headers into API requests; these headers are merged with existing request headers.
  * API client now accepts and exposes extra headers as part of its configuration snapshot.

* **Tests**
  * Added unit tests for header parsing, trimming, empty-input handling, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->